### PR TITLE
fix(nats): correcting nats jetstreamns vs streams

### DIFF
--- a/app.go
+++ b/app.go
@@ -98,6 +98,9 @@ type (
 		// natsClient is the nats client for the application.
 		natsClient *nats.Conn
 
+		// natsJetStream is the nats jetstream for the application.
+		natsJetStream jetstream.JetStream
+
 		// natStream is the nats stream for the application.
 		natsStream jetstream.Stream
 	}
@@ -383,7 +386,12 @@ func (a *App) NatsClient() *nats.Conn {
 }
 
 // NatsJetStream returns the JetStream stream for the application.
-func (a *App) NatsJetStream() jetstream.Stream {
+func (a *App) NatsJetStream() jetstream.JetStream {
+	return a.natsJetStream
+}
+
+// NatsStream returns the NATS stream for the application.
+func (a *App) NatsStream() jetstream.Stream {
 	return a.natsStream
 }
 

--- a/options.go
+++ b/options.go
@@ -352,6 +352,7 @@ func WithNatsJetStream(streamName string, subjects []string) StartOption {
 		if err != nil {
 			return fmt.Errorf("failed to create jetstream: %w", err)
 		}
+		a.natsJetStream = js
 
 		_, err = js.CreateStream(a.baseCtx, jetstream.StreamConfig{
 			Name:      streamName,


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces changes to integrate NATS JetStream more comprehensively into the application. The most important changes include adding a new field for JetStream in the application structure, updating the method to return the JetStream instance, and setting the JetStream instance during the application start.

Enhancements to NATS JetStream integration:

* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR101-R103): Added a new field `natsJetStream` to store the JetStream instance in the application structure.
* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL386-R394): Updated the `NatsJetStream` method to return the JetStream instance instead of the stream, and added a new `NatsStream` method to return the NATS stream.
* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R355): Set the `natsJetStream` field in the `WithNatsJetStream` function to store the created JetStream instance.