### PR TITLE
chore(health): updating the options for the health package

### DIFF
--- a/health/check.go
+++ b/health/check.go
@@ -33,7 +33,7 @@ type Check struct {
 
 // NewCheck creates a new Check
 //
-// You are able to return custom statuses by returning a StatusError from the check function. This was you can perform
+// You are able to return custom statuses by returning a StatusError from the check function. This way you can perform
 // checks that return a status other than up or down. For example, you can return a status of "degraded" if the check
 // is partially failing. This is useful for checks that are not binary in nature.
 func NewCheck(name string, checkerFunc CheckFunc, options ...CheckOption) *Check {

--- a/health/check.go
+++ b/health/check.go
@@ -3,10 +3,7 @@ package health
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"time"
-
-	"github.com/jacobbrewer1/web/logging"
 )
 
 type CheckFunc = func(ctx context.Context) error
@@ -35,6 +32,10 @@ type Check struct {
 }
 
 // NewCheck creates a new Check
+//
+// You are able to return custom statuses by returning a StatusError from the check function. This was you can perform
+// checks that return a status other than up or down. For example, you can return a status of "degraded" if the check
+// is partially failing. This is useful for checks that are not binary in nature.
 func NewCheck(name string, checkerFunc CheckFunc, options ...CheckOption) *Check {
 	c := &Check{
 		name:    name,
@@ -50,23 +51,11 @@ func NewCheck(name string, checkerFunc CheckFunc, options ...CheckOption) *Check
 	return c
 }
 
-// NewCheckWithStandardListener creates a new Check with a standard status listener
-func NewCheckWithStandardListener(l *slog.Logger, name string, checkerFunc CheckFunc, options ...CheckOption) *Check {
-	l = logging.LoggerWithComponent(l, "health-checker")
-	c := NewCheck(name, checkerFunc, options...)
-	c.statusListener = func(ctx context.Context, name string, state State) {
-		l.Info("health check status changed",
-			slog.String(logging.KeyName, name),
-			slog.String(logging.KeyState, state.Status().String()),
-		)
-	}
-	return c
-}
-
 func (c *Check) String() string {
 	return c.name
 }
 
+// Check performs the check and updates the state of the check.
 func (c *Check) Check(ctx context.Context) error {
 	now := Timestamp()
 	c.state.lastCheckTime = now

--- a/health/check_options.go
+++ b/health/check_options.go
@@ -7,35 +7,31 @@ import (
 
 type CheckOption = func(*Check)
 
-// CheckWithTimeout sets the timeout for the check.
-func CheckWithTimeout(timeout time.Duration) CheckOption {
+type StatusListenerFunc = func(ctx context.Context, name string, state State)
+
+// WithCheckTimeout sets the timeout for the check.
+func WithCheckTimeout(timeout time.Duration) CheckOption {
 	return func(c *Check) {
 		c.timeout = timeout
 	}
 }
 
-// CheckWithMaxTimeInError sets the maximum time the check can be in an error state before it is marked as down.
-// The check will be marked as down if the time in error exceeds this value.
-// This is useful for checks that may take a long time to recover from an error.
-// For example, if a check takes 5 minutes to recover from an error, you can set this value to 10 minutes.
-// This will allow the check to be in an error state for up to 10 minutes before it is marked as down.
-func CheckWithMaxTimeInError(maxTimeInError time.Duration) CheckOption {
+// WithCheckErrorGracePeriod sets the maximum time the check can be in an error state before it is marked as down.
+func WithCheckErrorGracePeriod(maxTimeInError time.Duration) CheckOption {
 	return func(c *Check) {
 		c.maxTimeInError = maxTimeInError
 	}
 }
 
-// CheckWithMaxContiguousFails sets the maximum number of contiguous fails.
-//
-// The check will be marked as up until the number of contiguous fails equals or exceeds this value.
-func CheckWithMaxContiguousFails(maxContiguousFails uint) CheckOption {
+// WithCheckMaxFailures sets the maximum number of contiguous fails.
+func WithCheckMaxFailures(maxContiguousFails uint) CheckOption {
 	return func(c *Check) {
 		c.maxContiguousFails = maxContiguousFails
 	}
 }
 
-// CheckWithStatusListener sets the status listener for the check.
-func CheckWithStatusListener(statusListener func(ctx context.Context, name string, state State)) CheckOption {
+// WithCheckOnStatusChange sets the status listener for the check.
+func WithCheckOnStatusChange(statusListener StatusListenerFunc) CheckOption {
 	return func(c *Check) {
 		c.statusListener = statusListener
 	}

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -17,7 +17,7 @@ func TestCheck_Check_Golden(t *testing.T) {
 	c := NewCheck("test", func(ctx context.Context) error {
 		return nil
 	},
-		CheckWithStatusListener(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
 			statusListenerCalled = true
 			require.Equal(t, "test", name, "StatusListener should receive the correct name")
 			require.Equal(t, StatusUp, state.status, "StatusListener should receive the correct status")
@@ -47,7 +47,7 @@ func TestCheck_Check_Golden_FailCheck(t *testing.T) {
 	c := NewCheck("test", func(ctx context.Context) error {
 		return errors.New("test error")
 	},
-		CheckWithStatusListener(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
 			statusListenerCalled = true
 			require.Equal(t, "test", name, "StatusListener should receive the correct name")
 			require.Equal(t, StatusDown, state.status, "StatusListener should receive the correct status")
@@ -82,7 +82,7 @@ func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
 		}
 		return nil
 	},
-		CheckWithStatusListener(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
 			statusListenerCalled++
 			if statusListenerCalled%2 == 0 {
 				require.Equal(t, "test", name, "StatusListener should receive the correct name")
@@ -143,8 +143,8 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 	c := NewCheck("test", func(ctx context.Context) error {
 		return errors.New("test error")
 	},
-		CheckWithMaxContiguousFails(3),
-		CheckWithStatusListener(func(ctx context.Context, name string, state State) {
+		WithCheckMaxFailures(3),
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
 			statusListenerCalled++
 			require.Equal(t, "test", name, "StatusListener should receive the correct name")
 

--- a/health/checker_options.go
+++ b/health/checker_options.go
@@ -6,8 +6,8 @@ import (
 
 type CheckerOption func(*checker)
 
-// CheckerWithBaseContext sets the base context for the checker.
-func CheckerWithBaseContext(baseCtx context.Context) CheckerOption {
+// WithCheckerBaseContext sets the base context for the checker.
+func WithCheckerBaseContext(baseCtx context.Context) CheckerOption {
 	return func(c *checker) {
 		ctx, cancel := context.WithCancel(baseCtx)
 		c.baseCtx = ctx
@@ -15,8 +15,8 @@ func CheckerWithBaseContext(baseCtx context.Context) CheckerOption {
 	}
 }
 
-// CheckerWithCheck sets the checks for the checker.
-func CheckerWithCheck(check *Check) CheckerOption {
+// WithCheckerCheck adds a single check to the checker.
+func WithCheckerCheck(check *Check) CheckerOption {
 	return func(c *checker) {
 		if check == nil {
 			return
@@ -28,15 +28,24 @@ func CheckerWithCheck(check *Check) CheckerOption {
 	}
 }
 
-// CheckerWithHTTPStatusCodeUp sets the HTTP status code for the checker when the system is up.
-func CheckerWithHTTPStatusCodeUp(code int) CheckerOption {
+// WithCheckerChecks adds multiple checks to the checker.
+func WithCheckerChecks(checks ...*Check) CheckerOption {
+	return func(c *checker) {
+		for _, check := range checks {
+			WithCheckerCheck(check)(c)
+		}
+	}
+}
+
+// WithCheckerHTTPCodeUp sets the HTTP status code when the system is up.
+func WithCheckerHTTPCodeUp(code int) CheckerOption {
 	return func(c *checker) {
 		c.httpStatusCodeUp = code
 	}
 }
 
-// CheckerWithHTTPStatusCodeDown sets the HTTP status code for the checker when the system is down.
-func CheckerWithHTTPStatusCodeDown(code int) CheckerOption {
+// WithCheckerHTTPCodeDown sets the HTTP status code when the system is down.
+func WithCheckerHTTPCodeDown(code int) CheckerOption {
 	return func(c *checker) {
 		c.httpStatusCodeDown = code
 	}

--- a/health/checker_test.go
+++ b/health/checker_test.go
@@ -18,7 +18,7 @@ func TestNewChecker(t *testing.T) {
 		return nil
 	})
 
-	got := NewChecker(CheckerWithCheck(gotCheck))
+	got := NewChecker(WithCheckerCheck(gotCheck))
 
 	c, ok := got.(*checker)
 	require.True(t, ok, "NewChecker() should return a *checker")
@@ -36,7 +36,7 @@ func TestNewCheckerHandler_Single(t *testing.T) {
 		return nil
 	})
 
-	got := NewChecker(CheckerWithCheck(gotCheck))
+	got := NewChecker(WithCheckerCheck(gotCheck))
 
 	handler := got.Handler()
 	require.NotNil(t, handler, "Handler() should return a non-nil http.HandlerFunc")
@@ -66,7 +66,7 @@ func TestNewCheckerHandler_Multiple(t *testing.T) {
 		return nil
 	})
 
-	got := NewChecker(CheckerWithCheck(gotCheck), CheckerWithCheck(secondCheck))
+	got := NewChecker(WithCheckerChecks([]*Check{gotCheck, secondCheck}...))
 
 	handler := got.Handler()
 	require.NotNil(t, handler, "Handler() should return a non-nil http.HandlerFunc")
@@ -92,7 +92,7 @@ func TestNewCheckerHandler_Single_Error(t *testing.T) {
 		return errors.New("test error")
 	})
 
-	got := NewChecker(CheckerWithCheck(gotCheck))
+	got := NewChecker(WithCheckerCheck(gotCheck))
 
 	handler := got.Handler()
 	require.NotNil(t, handler, "Handler() should return a non-nil http.HandlerFunc")

--- a/health/state.go
+++ b/health/state.go
@@ -22,26 +22,42 @@ type State struct {
 	status Status
 }
 
+// CheckErr is the last error returned by the check.
+//
+// Note: This is cleared when the check is successful.
 func (s *State) CheckErr() error {
 	return s.checkErr
 }
 
+// ContiguousFails is the number of contiguous failures.
+//
+// Note: This is cleared when the check is successful.
 func (s *State) ContiguousFails() uint {
 	return s.contiguousFails
 }
 
+// LastFail is the last time the check failed.
+//
+// Note: This is persistent across successes and failures. If there is a success, this
+// will be the last time the check failed.
 func (s *State) LastFail() time.Time {
 	return s.lastFail
 }
 
+// LastSuccess is the last time the check was successful.
+//
+// Note: This is persistent across successes and failures. If there is a failure, this
+// will be the last time the check was successful.
 func (s *State) LastSuccess() time.Time {
 	return s.lastSuccess
 }
 
+// LastCheckTime is the last time the check was performed.
 func (s *State) LastCheckTime() time.Time {
 	return s.lastCheckTime
 }
 
+// Status is the current status of the check.
 func (s *State) Status() Status {
 	return s.status
 }

--- a/health/status.go
+++ b/health/status.go
@@ -2,7 +2,11 @@ package health
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"log/slog"
+
+	"github.com/jacobbrewer1/web/logging"
 )
 
 type Status int
@@ -57,4 +61,13 @@ func (s Status) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func StandardStatusListener(l *slog.Logger) StatusListenerFunc {
+	return func(ctx context.Context, name string, state State) {
+		l.Info("health check status changed",
+			slog.String(logging.KeyName, name),
+			slog.String(logging.KeyState, state.Status().String()),
+		)
+	}
 }

--- a/options.go
+++ b/options.go
@@ -180,7 +180,7 @@ func WithHealthCheck(checks ...*health.Check) StartOption {
 	return func(a *App) error {
 		checkerOpts := make([]health.CheckerOption, 0)
 		for _, check := range checks {
-			checkerOpts = append(checkerOpts, health.CheckerWithCheck(check))
+			checkerOpts = append(checkerOpts, health.WithCheckerCheck(check))
 		}
 
 		checker := health.NewChecker(checkerOpts...)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the health check system, focusing on renaming functions for consistency, removing unnecessary methods, and adding new functionalities. Here are the most important changes:

### Function Renaming for Consistency:
* Renamed `CheckWithTimeout` to `WithCheckTimeout` in `health/check_options.go`.
* Renamed `CheckWithMaxTimeInError` to `WithCheckErrorGracePeriod` in `health/check_options.go`.
* Renamed `CheckWithMaxContiguousFails` to `WithCheckMaxFailures` in `health/check_options.go`.
* Renamed `CheckWithStatusListener` to `WithCheckOnStatusChange` in `health/check_options.go`.
* Renamed `CheckerWithBaseContext` to `WithCheckerBaseContext` in `health/checker_options.go`.
* Renamed `CheckerWithCheck` to `WithCheckerCheck` and `CheckerWithChecks` to `WithCheckerChecks` in `health/checker_options.go`.
* Renamed `CheckerWithHTTPStatusCodeUp` to `WithCheckerHTTPCodeUp` and `CheckerWithHTTPStatusCodeDown` to `WithCheckerHTTPCodeDown` in `health/checker_options.go`.

### Removal of Unnecessary Methods:
* Removed the `NewCheckWithStandardListener` function from `health/check.go`.

### Adding New Functionalities:
* Added the `StandardStatusListener` function in `health/status.go` to provide a standard way to log health check status changes.

### Documentation and Comments:
* Added detailed comments to the `NewCheck` function in `health/check.go` to explain the usage of custom statuses.
* Added comments to the `State` struct methods in `health/state.go` to describe their behavior and note when values are cleared or persistent.

### Test Updates:
* Updated test functions in `health/check_test.go` and `health/checker_test.go` to use the new function names. [[1]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1L20-R20) [[2]](diffhunk://#diff-b34a9fde0fea4438a9aa024a22b7ca2e7b8ff4a2e2c1f59034e9cb043d617755L21-R21)