### PR TITLE
fix(app): adding the max age to the jetstream config

### DIFF
--- a/options.go
+++ b/options.go
@@ -329,8 +329,7 @@ func WithNatsJetStream(streamName string, subjects []string) StartOption {
 			Name:      streamName,
 			Subjects:  subjects,
 			Storage:   jetstream.FileStorage,
-			Retention: jetstream.LimitsPolicy,
-			MaxAge:    3 * (24 * time.Hour),
+			Retention: jetstream.WorkQueuePolicy,
 		})
 		if err != nil && !errors.Is(err, jetstream.ErrStreamNameAlreadyInUse) {
 			return fmt.Errorf("failed to create stream: %w", err)

--- a/options.go
+++ b/options.go
@@ -330,6 +330,7 @@ func WithNatsJetStream(streamName string, subjects []string) StartOption {
 			Subjects:  subjects,
 			Storage:   jetstream.FileStorage,
 			Retention: jetstream.LimitsPolicy,
+			MaxAge:    3 * (24 * time.Hour),
 		})
 		if err != nil && !errors.Is(err, jetstream.ErrStreamNameAlreadyInUse) {
 			return fmt.Errorf("failed to create stream: %w", err)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small change to the `options.go` file. The change sets a maximum age for messages in the NATS JetStream configuration.

* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R333): Added `MaxAge` to the JetStream configuration to set the maximum age for messages to 3 days.