### PR TITLE
chore(app): allowing the user to specify the retention for the nats jetstream

### DIFF
--- a/options.go
+++ b/options.go
@@ -316,7 +316,7 @@ func WithInClusterNatsClient() StartOption {
 	return WithNatsClient(inClusterNatsEndpoint)
 }
 
-// WithNatsJetStream is a StartOption that sets up nats jetstream.
+// WithNatsJetStream is a StartOption that sets up nats jetstream with the given stream name, retention policy, and subjects.
 func WithNatsJetStream(streamName string, retentionPolicy jetstream.RetentionPolicy, subjects []string) StartOption {
 	return func(a *App) error {
 		js, err := jetstream.New(a.natsClient)

--- a/options.go
+++ b/options.go
@@ -317,7 +317,7 @@ func WithInClusterNatsClient() StartOption {
 }
 
 // WithNatsJetStream is a StartOption that sets up nats jetstream.
-func WithNatsJetStream(streamName string, subjects []string) StartOption {
+func WithNatsJetStream(streamName string, retentionPolicy jetstream.RetentionPolicy, subjects []string) StartOption {
 	return func(a *App) error {
 		js, err := jetstream.New(a.natsClient)
 		if err != nil {
@@ -329,7 +329,7 @@ func WithNatsJetStream(streamName string, subjects []string) StartOption {
 			Name:      streamName,
 			Subjects:  subjects,
 			Storage:   jetstream.FileStorage,
-			Retention: jetstream.WorkQueuePolicy,
+			Retention: retentionPolicy,
 		})
 		if err != nil && !errors.Is(err, jetstream.ErrStreamNameAlreadyInUse) {
 			return fmt.Errorf("failed to create stream: %w", err)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `WithNatsJetStream` function in the `options.go` file to add more flexibility in configuring the NATS JetStream retention policy.

Enhancements to NATS JetStream configuration:

* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L320-R320): Modified the `WithNatsJetStream` function to accept a `retentionPolicy` parameter in addition to `streamName` and `subjects`. This allows for more flexible configuration of the JetStream retention policy.
* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L332-R332): Updated the `Retention` field in the JetStream configuration to use the new `retentionPolicy` parameter instead of the hardcoded `jetstream.WorkQueuePolicy`.