### PR TITLE
fix(logging): overriding keys if they are re-added to the logger

### DIFF
--- a/logging/dedupe_handler.go
+++ b/logging/dedupe_handler.go
@@ -1,0 +1,63 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+type dedupeHandler struct {
+	base slog.Handler
+
+	// precomputed deduplicated attributes — immutable
+	attrs []slog.Attr
+}
+
+func (d *dedupeHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return d.base.Enabled(ctx, level)
+}
+
+func (d *dedupeHandler) Handle(ctx context.Context, record slog.Record) error {
+	// Don't modify the original record — add deduplicated attrs temporarily
+	record = record.Clone()
+	record.AddAttrs(d.attrs...)
+	return d.base.Handle(ctx, record)
+}
+
+func (d *dedupeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	combined := make(map[string]slog.Attr)
+
+	// Start with existing deduped attrs
+	for _, attr := range d.attrs {
+		combined[attr.Key] = attr
+	}
+
+	// Add new attrs, overriding duplicates
+	for _, attr := range attrs {
+		combined[attr.Key] = attr
+	}
+
+	// Rebuild slice
+	newAttrs := make([]slog.Attr, 0, len(combined))
+	for _, attr := range combined {
+		newAttrs = append(newAttrs, attr)
+	}
+
+	return &dedupeHandler{
+		base:  d.base,
+		attrs: newAttrs,
+	}
+}
+
+func (d *dedupeHandler) WithGroup(name string) slog.Handler {
+	return &dedupeHandler{
+		base:  d.base.WithGroup(name),
+		attrs: d.attrs,
+	}
+}
+
+func NewDedupeHandler(base slog.Handler) slog.Handler {
+	return &dedupeHandler{
+		base:  base,
+		attrs: make([]slog.Attr, 0),
+	}
+}

--- a/logging/dedupe_handler.go
+++ b/logging/dedupe_handler.go
@@ -16,7 +16,7 @@ func (d *dedupeHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return d.base.Enabled(ctx, level)
 }
 
-func (d *dedupeHandler) Handle(ctx context.Context, record slog.Record) error {
+func (d *dedupeHandler) Handle(ctx context.Context, record slog.Record) error { // nolint:gocritic // Part of an interface
 	// Don't modify the original record — add deduplicated attrs temporarily
 	record = record.Clone()
 	record.AddAttrs(d.attrs...)

--- a/logging/dedupe_handler_bench_test.go
+++ b/logging/dedupe_handler_bench_test.go
@@ -21,7 +21,7 @@ func BenchmarkDeDupe_WithAttrs(b *testing.B) {
 	attr := slog.String("key", "value")
 
 	// Benchmark logging with deduplication and attribute handling
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		// Use the logger's Info method to log with attributes
 		handler.Info("test", attr)
 	}
@@ -62,7 +62,7 @@ func BenchmarkDeDupe_Handle(b *testing.B) {
 	b.ResetTimer()
 
 	// Benchmark logging with deduplication by calling the handler's Handle method
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		err := handler.Handler().Handle(context.Background(), record)
 		require.NoError(b, err)
 	}

--- a/logging/dedupe_handler_bench_test.go
+++ b/logging/dedupe_handler_bench_test.go
@@ -1,0 +1,85 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkDeDupe_WithAttrs(b *testing.B) {
+	buf := bytes.NewBuffer(nil)
+	handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+
+	// Reset the timer after initialization to exclude setup time
+	b.ResetTimer()
+
+	// Prefill the attribute to be used in the benchmark
+	attr := slog.String("key", "value")
+
+	// Benchmark logging with deduplication and attribute handling
+	for i := 0; i < b.N; i++ {
+		// Use the logger's Info method to log with attributes
+		handler.Info("test", attr)
+	}
+}
+
+func BenchmarkDeDupe_Handle_Parallel(b *testing.B) {
+	buf := bytes.NewBuffer(nil)
+	handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+
+	// Pre-fill the record to be logged in the benchmark
+	record := slog.NewRecord(time.Now().UTC(), slog.LevelInfo, "test", 0)
+
+	// Run benchmark with parallelism
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			err := handler.Handler().Handle(context.Background(), record)
+			if err != nil {
+				b.Errorf("failed to handle log record: %v", err)
+			}
+		}
+	})
+}
+
+func BenchmarkDeDupe_Handle(b *testing.B) {
+	// Set up the buffer and logger
+	buf := bytes.NewBuffer(nil)
+	handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+
+	// Prepare the record to log
+	record := slog.NewRecord(
+		time.Now().UTC(),
+		slog.LevelInfo,
+		"test",
+		0,
+	)
+
+	// Reset the timer to exclude setup time from benchmarking
+	b.ResetTimer()
+
+	// Benchmark logging with deduplication by calling the handler's Handle method
+	for i := 0; i < b.N; i++ {
+		err := handler.Handler().Handle(context.Background(), record)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkDeDupe_WithAttrs_Parallel(b *testing.B) {
+	buf := bytes.NewBuffer(nil)
+	handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+
+	// Pre-fill the attribute to be used in the benchmark
+	attr := slog.String("key", "value")
+
+	// Run benchmark with parallelism
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Use the logger's Info method to log with attributes
+			handler.Info("test", attr)
+		}
+	})
+}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -14,11 +14,11 @@ func NewLogger(opts ...Option) *slog.Logger {
 func NewLoggerWithWriter(writer io.Writer, opts ...Option) *slog.Logger {
 	logCfg := newLoggingConfig()
 
-	l := slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{
+	l := slog.New(NewDedupeHandler(slog.NewJSONHandler(writer, &slog.HandlerOptions{
 		AddSource:   true,
 		Level:       logCfg.Level,
 		ReplaceAttr: replaceAttrs,
-	}))
+	})))
 
 	for _, opt := range opts {
 		opt(l)

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -35,3 +35,17 @@ func TestNewLogger_With(t *testing.T) {
 	require.Contains(t, got, `"level":"INFO"`)
 	require.Contains(t, got, `"handler":"test-handler"`)
 }
+
+func TestDuplicateKey(t *testing.T) {
+	buf := new(bytes.Buffer)
+	l := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+	l = LoggerWithComponent(l, "test-component-2") // This will duplicate the component key
+	l.Info("test")
+
+	got := buf.String()
+
+	require.Contains(t, got, `"app":"test"`)
+	require.Contains(t, got, `"component":"test-component-2"`)
+	require.NotContains(t, got, `"component":"test-component"`)
+	require.Contains(t, got, `"level":"INFO"`)
+}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces a new deduplication handler for logging and adds benchmark tests to ensure its performance. The changes include the creation of the `dedupeHandler` struct, updates to the logger initialization to use this new handler, and the addition of tests to verify the deduplication functionality.

### New deduplication handler:

* [`logging/dedupe_handler.go`](diffhunk://#diff-5060370d65295a9a13abd32f75b5f91f5bb1cc2090f1f58efec4012e2dcd1600R1-R63): Implemented the `dedupeHandler` struct to handle deduplication of log attributes. This includes methods for enabling logging, handling log records, and combining attributes without duplication.

### Benchmark tests:

* [`logging/dedupe_handler_bench_test.go`](diffhunk://#diff-13fb1392a0305950517660f9e96f7470268c46b3620fe4f1364902db9bbcebe0R1-R85): Added benchmark tests to measure the performance of the deduplication handler. These tests include scenarios for logging with attributes and handling log records in parallel.

### Logger initialization update:

* [`logging/logger.go`](diffhunk://#diff-19a22ab34725dc99b85cb111a4815502ed019f775ee0c19acdee7e0d1337febbL17-R21): Modified the `NewLoggerWithWriter` function to use the new `dedupeHandler` for JSON logging. This ensures that log attributes are deduplicated when the logger is initialized.

### Test for duplicate keys:

* [`logging/logger_test.go`](diffhunk://#diff-592d08cada4c87bd69e20d3eb1ac3b8d11c5482053528d03dd511611dcc9e517R38-R51): Added a test case to verify that duplicate keys are correctly handled by the deduplication handler. This test ensures that only the latest value for a duplicated key is retained in the log output.