### PR TITLE
feat(app): adding potential informers

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ linters:
     - tparallel
   settings:
     goconst:
-      ignore-strings: ""
       ignore-calls: true
     gocritic:
       enable-all: true

--- a/app.go
+++ b/app.go
@@ -86,7 +86,7 @@ type (
 		// podInformer is an informer for Kubernetes Pod objects.
 		podInformer kubeCache.SharedIndexInformer
 
-		// podLister is the pod listener for the application.
+		// podLister is a lister for Kubernetes Pod objects.
 		podLister listersv1.PodLister
 
 		// leaderElection is the leader election for the application.

--- a/cache/service_endpoint_hash_bucket_test.go
+++ b/cache/service_endpoint_hash_bucket_test.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"testing"
 	"time"
@@ -44,7 +43,7 @@ func Test_Lifecycle(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	l := slog.New(slog.NewTextHandler(io.Discard, nil))
+	l := slog.New(slog.DiscardHandler)
 	k := fake.NewClientset(ep)
 	sb := NewServiceEndpointHashBucket(l, k, "my-svc", "my-ns", "")
 	require.NoError(t, sb.Start(ctx))
@@ -97,7 +96,7 @@ func Test_onEndpointUpdate(t *testing.T) {
 	t.Parallel()
 
 	sb := &ServiceEndpointHashBucket{
-		l: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		l: slog.New(slog.DiscardHandler),
 		hr: hashring.New([]string{
 			"a",
 			"b",

--- a/options_helpers.go
+++ b/options_helpers.go
@@ -1,0 +1,18 @@
+package web
+
+import (
+	"time"
+
+	"k8s.io/client-go/informers"
+)
+
+// initKubernetesInformerFactory initialises the kubernetes informer factory for App.
+func initKubernetesInformerFactory(a *App, options ...informers.SharedInformerOption) {
+	// Set up an informer factory if one does not exist.
+	if a.kubernetesInformerFactory != nil {
+		return
+	}
+
+	// Set up a factory and informer to keep track of Kubernetes objects.
+	a.kubernetesInformerFactory = informers.NewSharedInformerFactoryWithOptions(a.kubeClient, time.Second*30, options...)
+}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces significant enhancements to the Kubernetes integration within the application. The changes include adding Kubernetes informers and listers, updating the service endpoint hash bucket, and providing new options for initializing Kubernetes informers.

### Kubernetes Integration Enhancements:

* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR27-R30): Added new imports for Kubernetes informers, listers, and cache tools. Introduced new fields in the `App` struct for Kubernetes informer factory, pod informer, and pod lister. Updated the `serviceEndpointHashBucket` type to a pointer. Added methods to return the Kubernetes informer factory, pod informer, and pod lister. [[1]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR27-R30) [[2]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR83-R91) [[3]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL96-R108) [[4]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL417-R447)

* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R23): Added a new import for Kubernetes informers. Introduced a new `WithKubernetesPodInformer` StartOption to initialize a Kubernetes SharedInformerFactory and informer for Kubernetes Pod objects. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R23) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R347-R362)

* [`options_helpers.go`](diffhunk://#diff-6d9fdbbe43948977695256f2195d49de269df46ad4511fe97cd3a5d7f84858b3R1-R18): Created a new file to define the `initKubernetesInformerFactory` function, which initializes the Kubernetes informer factory for the `App`.