### PR TITLE
feat(app): adding secret informers

### DIFF
--- a/app.go
+++ b/app.go
@@ -89,6 +89,12 @@ type (
 		// podLister is a lister for Kubernetes Pod objects.
 		podLister listersv1.PodLister
 
+		// secretInformer is an informer for Kubernetes Secret objects.
+		secretInformer kubeCache.SharedIndexInformer
+
+		// secretLister is a lister for Kubernetes Secret objects.
+		secretLister listersv1.SecretLister
+
 		// leaderElection is the leader election for the application.
 		leaderElection *leaderelection.LeaderElector
 
@@ -444,4 +450,14 @@ func (a *App) PodInformer() kubeCache.SharedIndexInformer {
 // KubernetesInformerFactory returns the Kubernetes informer factory for the application.
 func (a *App) KubernetesInformerFactory() informers.SharedInformerFactory {
 	return a.kubernetesInformerFactory
+}
+
+// SecretLister returns the secret lister for the application.
+func (a *App) SecretLister() listersv1.SecretLister {
+	return a.secretLister
+}
+
+// SecretInformer returns the secret informer for the application.
+func (a *App) SecretInformer() kubeCache.SharedIndexInformer {
+	return a.secretInformer
 }

--- a/options.go
+++ b/options.go
@@ -349,7 +349,7 @@ func WithNatsJetStream(streamName string, retentionPolicy jetstream.RetentionPol
 func WithKubernetesPodInformer(informerOptions ...informers.SharedInformerOption) StartOption {
 	return func(a *App) error {
 		if a.kubeClient == nil {
-			return errors.New("must set up kube client before pod lister, ensure WithInClusterKubeClient is called")
+			return errors.New("must set up kube client before pod informer, ensure WithInClusterKubeClient is called")
 		}
 
 		initKubernetesInformerFactory(a, informerOptions...)
@@ -366,7 +366,7 @@ func WithKubernetesPodInformer(informerOptions ...informers.SharedInformerOption
 func WithKubernetesSecretInformer(informerOptions ...informers.SharedInformerOption) StartOption {
 	return func(a *App) error {
 		if a.kubeClient == nil {
-			return errors.New("must set up kube client before secret lister, ensure WithInClusterKubeClient is called")
+			return errors.New("must set up kube client before secret informer, ensure WithInClusterKubeClient is called")
 		}
 
 		initKubernetesInformerFactory(a, informerOptions...)

--- a/options.go
+++ b/options.go
@@ -355,8 +355,26 @@ func WithKubernetesPodInformer(informerOptions ...informers.SharedInformerOption
 		initKubernetesInformerFactory(a, informerOptions...)
 
 		a.l.Info("creating kubernetes pod informer")
-		a.podInformer = a.kubernetesInformerFactory.Core().V1().Pods().Informer()
-		a.podLister = a.kubernetesInformerFactory.Core().V1().Pods().Lister()
+		base := a.kubernetesInformerFactory.Core().V1().Pods()
+		a.podInformer = base.Informer()
+		a.podLister = base.Lister()
+		return nil
+	}
+}
+
+// WithKubernetesSecretInformer is a StartOption that initialises a Kubernetes SharedInformerFactory and informer for Kubernetes Secret objects.
+func WithKubernetesSecretInformer(informerOptions ...informers.SharedInformerOption) StartOption {
+	return func(a *App) error {
+		if a.kubeClient == nil {
+			return errors.New("must set up kube client before secret lister, ensure WithInClusterKubeClient is called")
+		}
+
+		initKubernetesInformerFactory(a, informerOptions...)
+
+		a.l.Info("creating kubernetes secret informer")
+		base := a.kubernetesInformerFactory.Core().V1().Secrets()
+		a.secretInformer = base.Informer()
+		a.secretLister = base.Lister()
 		return nil
 	}
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces functionality to handle Kubernetes Secret objects in addition to the existing Pod objects. The main changes include adding informers and listers for Secrets and creating a new option to initialize these components.

Kubernetes Secret handling:

* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR92-R97): Added `secretInformer` and `secretLister` fields to the `App` struct and implemented `SecretLister` and `SecretInformer` methods. [[1]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR92-R97) [[2]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR454-R463)
* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L358-R377): Added the `WithKubernetesSecretInformer` function to initialize the Kubernetes SharedInformerFactory and informer for Secret objects.