### PR TITLE
chore(app): using getters to handle fetching required fields

### DIFF
--- a/options.go
+++ b/options.go
@@ -152,7 +152,7 @@ func WithLeaderElection(lockName string) StartOption {
 			return errors.New("lock name cannot be empty")
 		}
 
-		kc := a.KubeClient()
+		kubeClient := a.KubeClient()
 
 		klog.SetSlogLogger(logging.LoggerWithComponent(a.Logger(), "klog"))
 
@@ -171,7 +171,7 @@ func WithLeaderElection(lockName string) StartOption {
 					Name:      lockName,
 					Namespace: ns,
 				},
-				Client: kc.CoordinationV1(),
+				Client: kubeClient.CoordinationV1(),
 				LockConfig: resourcelock.ResourceLockConfig{
 					Identity: utils.PodName,
 				},
@@ -308,7 +308,7 @@ func WithIndefiniteAsyncTask(name string, fn AsyncTaskFunc) StartOption {
 // WithServiceEndpointHashBucket is a StartOption that sets up the service endpoint hash bucket.
 func WithServiceEndpointHashBucket(appName string) StartOption {
 	return func(a *App) error {
-		kc := a.KubeClient()
+		kubeClient := a.KubeClient()
 
 		ns, err := utils.GetDeployedKubernetesNamespace()
 		if err != nil {
@@ -317,7 +317,7 @@ func WithServiceEndpointHashBucket(appName string) StartOption {
 
 		sb := cache.NewServiceEndpointHashBucket(
 			logging.LoggerWithComponent(a.l, "service_endpoint_hash_bucket"),
-			kc,
+			kubeClient,
 			appName,
 			ns,
 			utils.PodName,
@@ -354,9 +354,9 @@ func WithInClusterNatsClient() StartOption {
 // WithNatsJetStream is a StartOption that sets up nats jetstream with the given stream name, retention policy, and subjects.
 func WithNatsJetStream(streamName string, retentionPolicy jetstream.RetentionPolicy, subjects []string) StartOption {
 	return func(a *App) error {
-		nc := a.NatsClient()
+		natsClient := a.NatsClient()
 
-		js, err := jetstream.New(nc)
+		js, err := jetstream.New(natsClient)
 		if err != nil {
 			return fmt.Errorf("failed to create jetstream: %w", err)
 		}

--- a/options.go
+++ b/options.go
@@ -39,8 +39,8 @@ const (
 )
 
 var (
-	ErrNilVaultClient = errors.New("nil vault client")
-	ErrNoHostname     = errors.New("no hostname provided")
+	// ErrNoHostname is returned when the hostname is not set.
+	ErrNoHostname = errors.New("no hostname provided")
 )
 
 // AsyncTaskFunc is a function that performs an async task.
@@ -91,10 +91,7 @@ func WithVaultClient() StartOption {
 // WithDatabaseFromVault is a StartOption that sets up the database from vault.
 func WithDatabaseFromVault() StartOption {
 	return func(a *App) error {
-		vc := a.vaultClient
-		if vc == nil {
-			return ErrNilVaultClient
-		}
+		vc := a.VaultClient()
 
 		vs, err := vc.Path(
 			a.vip.GetString("vault.database.role"),
@@ -149,15 +146,15 @@ func WithInClusterKubeClient() StartOption {
 func WithLeaderElection(lockName string) StartOption {
 	return func(a *App) error {
 		switch {
-		case a.kubeClient == nil:
-			return errors.New("must set up kube client before leader election, ensure WithInClusterKubeClient is called")
 		case utils.PodName == "":
 			return ErrNoHostname
 		case lockName == "":
 			return errors.New("lock name cannot be empty")
 		}
 
-		klog.SetSlogLogger(logging.LoggerWithComponent(a.l, "klog"))
+		kc := a.KubeClient()
+
+		klog.SetSlogLogger(logging.LoggerWithComponent(a.Logger(), "klog"))
 
 		a.leaderChange = make(chan struct{})
 
@@ -174,7 +171,7 @@ func WithLeaderElection(lockName string) StartOption {
 					Name:      lockName,
 					Namespace: ns,
 				},
-				Client: a.kubeClient.CoordinationV1(),
+				Client: kc.CoordinationV1(),
 				LockConfig: resourcelock.ResourceLockConfig{
 					Identity: utils.PodName,
 				},
@@ -239,12 +236,11 @@ func WithHealthCheck(checks ...*health.Check) StartOption {
 // WithRedisPool is a StartOption that sets up the redis pool.
 func WithRedisPool() StartOption {
 	return func(a *App) error {
-		if a.vaultClient == nil {
-			return ErrNilVaultClient
-		}
+		vip := a.Viper()
+		vc := a.VaultClient()
 
-		keydbPath := a.vip.GetString("vault.keydb.name")
-		keydbSecret, err := a.vaultClient.Path(keydbPath).GetKvSecretV2(a.baseCtx)
+		keydbPath := vip.GetString("vault.keydb.name")
+		keydbSecret, err := vc.Path(keydbPath).GetKvSecretV2(a.baseCtx)
 		if errors.Is(err, vaulty.ErrSecretNotFound) {
 			return fmt.Errorf("keydb secrets not found in vault path: %s", keydbPath)
 		} else if err != nil {
@@ -258,11 +254,11 @@ func WithRedisPool() StartOption {
 
 		rp, err := goredis.NewPool(
 			goredis.WithLogger(logging.LoggerWithComponent(a.l, "goredis")),
-			goredis.WithAddress(a.vip.GetString("keydb.address")),
-			goredis.WithNetwork(a.vip.GetString("keydb.network")),
+			goredis.WithAddress(vip.GetString("keydb.address")),
+			goredis.WithNetwork(vip.GetString("keydb.network")),
 			goredis.WithDialOpts(
 				redis.DialPassword(redisPassword),
-				redis.DialDatabase(a.vip.GetInt("keydb.database")),
+				redis.DialDatabase(vip.GetInt("keydb.database")),
 			),
 		)
 		if err != nil {
@@ -312,9 +308,7 @@ func WithIndefiniteAsyncTask(name string, fn AsyncTaskFunc) StartOption {
 // WithServiceEndpointHashBucket is a StartOption that sets up the service endpoint hash bucket.
 func WithServiceEndpointHashBucket(appName string) StartOption {
 	return func(a *App) error {
-		if a.kubeClient == nil {
-			return errors.New("must set up kube client before service endpoint hash bucket, ensure WithInClusterKubeClient is called")
-		}
+		kc := a.KubeClient()
 
 		ns, err := utils.GetDeployedKubernetesNamespace()
 		if err != nil {
@@ -323,7 +317,7 @@ func WithServiceEndpointHashBucket(appName string) StartOption {
 
 		sb := cache.NewServiceEndpointHashBucket(
 			logging.LoggerWithComponent(a.l, "service_endpoint_hash_bucket"),
-			a.kubeClient,
+			kc,
 			appName,
 			ns,
 			utils.PodName,
@@ -360,7 +354,9 @@ func WithInClusterNatsClient() StartOption {
 // WithNatsJetStream is a StartOption that sets up nats jetstream with the given stream name, retention policy, and subjects.
 func WithNatsJetStream(streamName string, retentionPolicy jetstream.RetentionPolicy, subjects []string) StartOption {
 	return func(a *App) error {
-		js, err := jetstream.New(a.natsClient)
+		nc := a.NatsClient()
+
+		js, err := jetstream.New(nc)
 		if err != nil {
 			return fmt.Errorf("failed to create jetstream: %w", err)
 		}
@@ -388,10 +384,6 @@ func WithNatsJetStream(streamName string, retentionPolicy jetstream.RetentionPol
 // WithKubernetesPodInformer is a StartOption that initialises a Kubernetes SharedInformerFactory and informer for Kubernetes Pod objects.
 func WithKubernetesPodInformer(informerOptions ...informers.SharedInformerOption) StartOption {
 	return func(a *App) error {
-		if a.kubeClient == nil {
-			return errors.New("must set up kube client before pod informer, ensure WithInClusterKubeClient is called")
-		}
-
 		initKubernetesInformerFactory(a, informerOptions...)
 
 		a.l.Info("creating kubernetes pod informer")
@@ -405,10 +397,6 @@ func WithKubernetesPodInformer(informerOptions ...informers.SharedInformerOption
 // WithKubernetesSecretInformer is a StartOption that initialises a Kubernetes SharedInformerFactory and informer for Kubernetes Secret objects.
 func WithKubernetesSecretInformer(informerOptions ...informers.SharedInformerOption) StartOption {
 	return func(a *App) error {
-		if a.kubeClient == nil {
-			return errors.New("must set up kube client before secret informer, ensure WithInClusterKubeClient is called")
-		}
-
 		initKubernetesInformerFactory(a, informerOptions...)
 
 		a.l.Info("creating kubernetes secret informer")

--- a/options_helpers.go
+++ b/options_helpers.go
@@ -13,8 +13,8 @@ func initKubernetesInformerFactory(a *App, options ...informers.SharedInformerOp
 		return
 	}
 
-	kc := a.KubeClient()
+	kubeClient := a.KubeClient()
 
 	// Set up a factory and informer to keep track of Kubernetes objects.
-	a.kubernetesInformerFactory = informers.NewSharedInformerFactoryWithOptions(kc, time.Second*30, options...)
+	a.kubernetesInformerFactory = informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Second*30, options...)
 }

--- a/options_helpers.go
+++ b/options_helpers.go
@@ -13,6 +13,8 @@ func initKubernetesInformerFactory(a *App, options ...informers.SharedInformerOp
 		return
 	}
 
+	kc := a.KubeClient()
+
 	// Set up a factory and informer to keep track of Kubernetes objects.
-	a.kubernetesInformerFactory = informers.NewSharedInformerFactoryWithOptions(a.kubeClient, time.Second*30, options...)
+	a.kubernetesInformerFactory = informers.NewSharedInformerFactoryWithOptions(kc, time.Second*30, options...)
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request makes several changes to the `options.go` file to improve the code by replacing direct access to client variables with getter methods and removing redundant error checks. The main changes include the following:

### Replacing direct client access with getter methods:

* Replaced direct access to `vaultClient` with the `VaultClient()` method in `func WithDatabaseFromVault()` and `func WithRedisPool()`. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L94-R94) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L242-R243)
* Replaced direct access to `kubeClient` with the `KubeClient()` method in `func WithLeaderElection()`, `func WithServiceEndpointHashBucket()`, and `func WithKubernetesPodInformer()`. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L152-R157) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L315-R311) [[3]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L391-L394)
* Replaced direct access to `natsClient` with the `NatsClient()` method in `func WithNatsJetStream()`.

### Removing redundant error checks:

* Removed redundant `nil` checks for `vaultClient` and `kubeClient` in various functions, as these checks are now handled by the getter methods. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L152-R157) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L391-L394)

### Other improvements:

* Added a comment for `ErrNoHostname` to provide more context about the error.
* Updated the `initKubernetesInformerFactory` function to use the `KubeClient()` method instead of directly accessing `kubeClient`.