### PR TITLE
fix(app): using missing getters

### DIFF
--- a/options.go
+++ b/options.go
@@ -79,7 +79,7 @@ func WithConfigWatchers(fn ...func()) StartOption {
 func WithVaultClient() StartOption {
 	return func(a *App) error {
 		vip := a.Viper()
-		vc, err := VaultClient(a.baseCtx, logging.LoggerWithComponent(a.l, "vault"), vip)
+		vc, err := VaultClient(a.baseCtx, logging.LoggerWithComponent(a.Logger(), "vault"), vip)
 		if err != nil {
 			return fmt.Errorf("error getting vault client: %w", err)
 		}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the `options.go` file to improve code readability and maintainability by introducing local variables for frequently accessed components (`Viper`, `Logger`, etc.). The most important changes include modifying the `WithVaultClient`, `WithDatabaseFromVault`, `WithLeaderElection`, `WithRedisPool`, and `WithKubernetesPodInformer` functions.

Improvements to code readability and maintainability:

* `func WithVaultClient() StartOption {` in `options.go`: Introduced a local variable `vip` for `a.Viper()` to reduce repetitive calls.
* `func WithDatabaseFromVault() StartOption {` in `options.go`: Introduced a local variable `vip` for `a.Viper()` to simplify the code and reduce repetitive calls. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R96-R103) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L110-R112)
* `func WithLeaderElection(lockName string) StartOption {` in `options.go`: Introduced a local variable `l` for `a.Logger()` to reduce repetitive calls and improve code clarity. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R157-R160) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L184-R193)
* `func WithRedisPool() StartOption {` in `options.go`: Introduced a local variable `l` for `a.Logger()` to reduce repetitive calls and improve readability. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R244) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L256-R260)
* `func WithKubernetesPodInformer(informerOptions ...informers.SharedInformerOption) StartOption {` in `options.go`: Introduced a local variable `l` for `a.Logger()` to improve code readability and maintainability. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R392-R396) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R407-R411)