### PR TITLE
fix(app): setting viper instance to prevent panic

### DIFF
--- a/options.go
+++ b/options.go
@@ -56,6 +56,7 @@ func WithViperConfig() StartOption {
 		if err := vip.ReadInConfig(); err != nil {
 			return fmt.Errorf("error reading config file into viper: %w", err)
 		}
+		a.vip = vip
 		return nil
 	}
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->
This pull request includes a small change to the `options.go` file. The change assigns the `vip` variable to the `a.vip` field within the `WithViperConfig` function.

* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R59): Added assignment of `vip` to `a.vip` within the `WithViperConfig` function to ensure the `vip` instance is properly stored.