### PR TITLE
fix(app): adding fixed hash bucket and tidying loose ends

### DIFF
--- a/app.go
+++ b/app.go
@@ -200,39 +200,49 @@ func (a *App) Start(opts ...StartOption) error {
 			go a.leaderElection.Run(a.baseCtx)
 		}
 
+		var serverErr error
 		a.servers.Range(func(name, srv any) bool {
 			serverName, ok := name.(string)
 			if !ok {
-				a.l.Error("failed to cast server name to string")
+				serverErr = errors.New("failed to cast server name to string")
 				return false
 			}
 
 			server, ok := srv.(*http.Server)
 			if !ok {
-				a.l.Error("failed to cast server to http.Server")
+				serverErr = fmt.Errorf("failed to cast server %s to http.Server", serverName)
 				return false
 			}
 
 			a.startServer(serverName, server)
 			return true
 		})
+		if serverErr != nil {
+			startErr = fmt.Errorf("server initialization error: %w", serverErr)
+			return
+		}
 
+		var taskErr error
 		a.indefiniteAsyncTasks.Range(func(name, fn any) bool {
 			taskName, ok := name.(string)
 			if !ok {
-				a.l.Error("failed to cast task name to string")
+				taskErr = errors.New("failed to cast task name to string")
 				return false
 			}
 
 			taskFn, ok := fn.(AsyncTaskFunc)
 			if !ok {
-				a.l.Error("failed to cast task function to AsyncTaskFunc")
+				taskErr = fmt.Errorf("failed to cast task function %s to AsyncTaskFunc", taskName)
 				return false
 			}
 
 			a.startAsyncTask(taskName, true, taskFn)
 			return true
 		})
+		if taskErr != nil { // nolint:revive // Traditional error handling
+			startErr = fmt.Errorf("async task initialization error: %w", taskErr)
+			return
+		}
 	})
 
 	a.waitUntilStarted()

--- a/app.go
+++ b/app.go
@@ -124,6 +124,9 @@ type (
 		// indefiniteAsyncTasks is the list of indefinite async tasks for the application.
 		indefiniteAsyncTasks sync.Map
 
+		// fixedHashBucket is the fixed hash bucket for the application.
+		fixedHashBucket *cache.FixedHashBucket
+
 		// serviceEndpointHashBucket is the service endpoint hash bucket for the application.
 		serviceEndpointHashBucket *cache.ServiceEndpointHashBucket
 
@@ -522,6 +525,15 @@ func (a *App) CreateNatsJetStreamConsumer(consumerName, subjectFilter string) (j
 	}
 
 	return cons, nil
+}
+
+// FixedHashBucket returns the fixed hash bucket for the application.
+func (a *App) FixedHashBucket() *cache.FixedHashBucket {
+	if a.fixedHashBucket == nil {
+		a.l.Error("fixed hash bucket has not been registered")
+		panic("fixed hash bucket has not been registered")
+	}
+	return a.fixedHashBucket
 }
 
 // ServiceEndpointHashBucket returns the service endpoint hash bucket for the application.

--- a/cache/fixed_hash_bucket.go
+++ b/cache/fixed_hash_bucket.go
@@ -1,0 +1,51 @@
+package cache
+
+import (
+	"strconv"
+
+	"github.com/serialx/hashring"
+)
+
+var _ HashBucket = new(FixedHashBucket)
+
+// FixedHashBucket represents a mechanism which determines whether supplied keys belong to the current bucket index.
+// It uses a consistent hashing ring to determine the bucket index for each key.
+// The bucket index is advanced in a round-robin fashion, and the keys are distributed across the buckets based on their hash values.
+type FixedHashBucket struct {
+	hr    *hashring.HashRing
+	index int
+}
+
+func NewFixedHashBucket(size uint) *FixedHashBucket {
+	h := &FixedHashBucket{
+		hr:    hashring.New(make([]string, 0)),
+		index: 0,
+	}
+
+	for i := range uint64(size) {
+		h.hr = h.hr.AddNode(strconv.FormatUint(i, 10))
+	}
+
+	return h
+}
+
+func (h *FixedHashBucket) InBucket(key string) bool {
+	pos, _ := h.hr.GetNodePos(key)
+	return pos == h.index
+}
+
+func (h *FixedHashBucket) Advance() {
+	if h.index+1 >= h.hr.Size() {
+		h.index = 0
+	} else {
+		h.index++
+	}
+}
+
+func (h *FixedHashBucket) GetIndex() int {
+	return h.index
+}
+
+func (h *FixedHashBucket) GetSize() int {
+	return h.hr.Size()
+}

--- a/cache/fixed_hash_bucket.go
+++ b/cache/fixed_hash_bucket.go
@@ -22,6 +22,7 @@ func NewFixedHashBucket(size uint) *FixedHashBucket {
 		index: 0,
 	}
 
+	// Add nodes to the hash ring based on the size.
 	for i := range uint64(size) {
 		h.hr = h.hr.AddNode(strconv.FormatUint(i, 10))
 	}

--- a/cache/fixed_hash_bucket.go
+++ b/cache/fixed_hash_bucket.go
@@ -16,6 +16,7 @@ type FixedHashBucket struct {
 	index int
 }
 
+// NewFixedHashBucket instantiates a FixedHashBucket of the provided size.
 func NewFixedHashBucket(size uint) *FixedHashBucket {
 	h := &FixedHashBucket{
 		hr:    hashring.New(make([]string, 0)),
@@ -30,23 +31,17 @@ func NewFixedHashBucket(size uint) *FixedHashBucket {
 	return h
 }
 
+// InBucket returns whether the supplied key resides in the current bucket.
 func (h *FixedHashBucket) InBucket(key string) bool {
 	pos, _ := h.hr.GetNodePos(key)
 	return pos == h.index
 }
 
+// Advance advances the current bucket index by 1. The index automatically wraps on index overflow.
 func (h *FixedHashBucket) Advance() {
 	if h.index+1 >= h.hr.Size() {
 		h.index = 0
 	} else {
 		h.index++
 	}
-}
-
-func (h *FixedHashBucket) GetIndex() int {
-	return h.index
-}
-
-func (h *FixedHashBucket) GetSize() int {
-	return h.hr.Size()
 }

--- a/cache/fixed_hash_bucket.go
+++ b/cache/fixed_hash_bucket.go
@@ -24,7 +24,7 @@ func NewFixedHashBucket(size uint) *FixedHashBucket {
 	}
 
 	// Add nodes to the hash ring based on the size.
-	for i := range uint64(size) {
+	for i := uint64(0); i < uint64(size); i++ { // nolint:intrange // Cannot use i range loops for uint64
 		h.hr = h.hr.AddNode(strconv.FormatUint(i, 10))
 	}
 

--- a/cache/fixed_hash_bucket_test.go
+++ b/cache/fixed_hash_bucket_test.go
@@ -1,0 +1,25 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_FixedHashBucket(t *testing.T) {
+	h := NewFixedHashBucket(2)
+	v := "hello"
+
+	in := h.InBucket(v)
+	h.Advance()
+	require.Equal(t, 1, h.index)
+
+	in2 := h.InBucket(v)
+
+	// Ensure that the same value cannot be in two buckets.
+	require.NotEqual(t, in, in2)
+
+	// Ensure Advance() wraps the index.
+	h.Advance()
+	require.Zero(t, h.index)
+}

--- a/cache/service_endpoint_hash_bucket.go
+++ b/cache/service_endpoint_hash_bucket.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+var _ HashBucket = new(ServiceEndpointHashBucket)
+
 // ServiceEndpointHashBucket represents a mechanism which determines whether the current application instance should process
 // a particular key. The bucket size is determined by the number of active endpoints in the supplied Kubernetes service.
 type ServiceEndpointHashBucket struct {
@@ -142,6 +144,7 @@ func endpointsToSet(endpoints *corev1.Endpoints) *slices.Set[string] {
 	return s
 }
 
+// Shutdown stops the informer factory and cleans up resources.
 func (sb *ServiceEndpointHashBucket) Shutdown() {
 	sb.informerFactory.Shutdown()
 }

--- a/logging/dedupe_handler.go
+++ b/logging/dedupe_handler.go
@@ -5,11 +5,23 @@ import (
 	"log/slog"
 )
 
+var _ slog.Handler = new(dedupeHandler)
+
+// dedupeHandler is a slog.Handler that deduplicates attributes.
 type dedupeHandler struct {
+	// base is the underlying slog.Handler to which we delegate
 	base slog.Handler
 
 	// precomputed deduplicated attributes — immutable
 	attrs []slog.Attr
+}
+
+// NewDedupeHandler creates a new slog.Handler that deduplicates attributes.
+func NewDedupeHandler(base slog.Handler) slog.Handler {
+	return &dedupeHandler{
+		base:  base,
+		attrs: make([]slog.Attr, 0),
+	}
 }
 
 func (d *dedupeHandler) Enabled(ctx context.Context, level slog.Level) bool {
@@ -52,12 +64,5 @@ func (d *dedupeHandler) WithGroup(name string) slog.Handler {
 	return &dedupeHandler{
 		base:  d.base.WithGroup(name),
 		attrs: d.attrs,
-	}
-}
-
-func NewDedupeHandler(base slog.Handler) slog.Handler {
-	return &dedupeHandler{
-		base:  base,
-		attrs: make([]slog.Attr, 0),
 	}
 }

--- a/logging/dedupe_handler_bench_test.go
+++ b/logging/dedupe_handler_bench_test.go
@@ -10,76 +10,198 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkDeDupe_WithAttrs(b *testing.B) {
-	buf := bytes.NewBuffer(nil)
-	handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+func TestDedupeHandler(t *testing.T) {
+	t.Parallel()
 
-	// Reset the timer after initialization to exclude setup time
-	b.ResetTimer()
+	t.Run("enabled passthrough", func(t *testing.T) {
+		t.Parallel()
+		buf := bytes.NewBuffer(nil)
+		base := slog.NewJSONHandler(buf, nil)
+		handler := NewDedupeHandler(base)
 
-	// Prefill the attribute to be used in the benchmark
-	attr := slog.String("key", "value")
+		require.Equal(t, base.Enabled(context.Background(), slog.LevelInfo),
+			handler.Enabled(context.Background(), slog.LevelInfo))
+	})
 
-	// Benchmark logging with deduplication and attribute handling
-	for range b.N {
-		// Use the logger's Info method to log with attributes
-		handler.Info("test", attr)
-	}
-}
+	t.Run("handle with deduplicated attrs", func(t *testing.T) {
+		t.Parallel()
+		buf := bytes.NewBuffer(nil)
+		base := slog.NewJSONHandler(buf, nil)
+		handler := NewDedupeHandler(base)
 
-func BenchmarkDeDupe_Handle_Parallel(b *testing.B) {
-	buf := bytes.NewBuffer(nil)
-	handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+		// Add some initial attributes
+		handler = handler.WithAttrs([]slog.Attr{
+			slog.String("key1", "value1"),
+			slog.Int("key2", 42),
+		})
 
-	// Pre-fill the record to be logged in the benchmark
-	record := slog.NewRecord(time.Now().UTC(), slog.LevelInfo, "test", 0)
+		record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+		err := handler.Handle(context.Background(), record)
+		require.NoError(t, err)
 
-	// Run benchmark with parallelism
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			err := handler.Handler().Handle(context.Background(), record)
-			if err != nil {
-				b.Errorf("failed to handle log record: %v", err)
-			}
-		}
+		result := buf.String()
+		require.Contains(t, result, `"key1":"value1"`)
+		require.Contains(t, result, `"key2":42`)
+	})
+
+	t.Run("withAttrs deduplication", func(t *testing.T) {
+		t.Parallel()
+		buf := bytes.NewBuffer(nil)
+		base := slog.NewJSONHandler(buf, nil)
+		handler := NewDedupeHandler(base)
+
+		// Add initial attributes
+		handler = handler.WithAttrs([]slog.Attr{
+			slog.String("key1", "value1"),
+			slog.Int("key2", 42),
+		})
+
+		// Add overlapping attributes
+		handler = handler.WithAttrs([]slog.Attr{
+			slog.String("key1", "newvalue"), // Should override
+			slog.String("key3", "value3"),   // Should add
+		})
+
+		record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+		err := handler.Handle(context.Background(), record)
+		require.NoError(t, err)
+
+		result := buf.String()
+		require.Contains(t, result, `"key1":"newvalue"`)
+		require.Contains(t, result, `"key2":42`)
+		require.Contains(t, result, `"key3":"value3"`)
+	})
+
+	t.Run("withGroup handling", func(t *testing.T) {
+		t.Parallel()
+		buf := bytes.NewBuffer(nil)
+		base := slog.NewJSONHandler(buf, nil)
+		handler := NewDedupeHandler(base)
+
+		// Add attributes and create group
+		handler = handler.WithAttrs([]slog.Attr{
+			slog.String("key1", "value1"),
+		})
+		groupHandler := handler.WithGroup("group1")
+
+		// Add more attributes to group
+		groupHandler = groupHandler.WithAttrs([]slog.Attr{
+			slog.Int("key2", 42),
+		})
+
+		record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+		err := groupHandler.Handle(context.Background(), record)
+		require.NoError(t, err)
+
+		result := buf.String()
+		require.Contains(t, result, `"key1":"value1"`)
+		require.Contains(t, result, `"key2":42`)
+	})
+
+	t.Run("record immutability", func(t *testing.T) {
+		t.Parallel()
+		buf := bytes.NewBuffer(nil)
+		base := slog.NewJSONHandler(buf, nil)
+		handler := NewDedupeHandler(base)
+
+		handler = handler.WithAttrs([]slog.Attr{
+			slog.String("key1", "value1"),
+		})
+
+		// Create original record
+		original := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+		originalAttrs := make([]slog.Attr, 0)
+		original.Attrs(func(a slog.Attr) bool {
+			originalAttrs = append(originalAttrs, a)
+			return true
+		})
+
+		// Handle the record
+		err := handler.Handle(context.Background(), original)
+		require.NoError(t, err)
+
+		// Verify original record wasn't modified
+		currentAttrs := make([]slog.Attr, 0)
+		original.Attrs(func(a slog.Attr) bool {
+			currentAttrs = append(currentAttrs, a)
+			return true
+		})
+		require.Equal(t, originalAttrs, currentAttrs)
 	})
 }
 
-func BenchmarkDeDupe_Handle(b *testing.B) {
-	// Set up the buffer and logger
-	buf := bytes.NewBuffer(nil)
-	handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+func BenchmarkDeDupe(b *testing.B) {
+	b.Run("WithAttr", func(b *testing.B) {
+		buf := bytes.NewBuffer(nil)
+		handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
 
-	// Prepare the record to log
-	record := slog.NewRecord(
-		time.Now().UTC(),
-		slog.LevelInfo,
-		"test",
-		0,
-	)
+		// Reset the timer after initialization to exclude setup time
+		b.ResetTimer()
 
-	// Reset the timer to exclude setup time from benchmarking
-	b.ResetTimer()
+		// Prefill the attribute to be used in the benchmark
+		attr := slog.String("key", "value")
 
-	// Benchmark logging with deduplication by calling the handler's Handle method
-	for range b.N {
-		err := handler.Handler().Handle(context.Background(), record)
-		require.NoError(b, err)
-	}
-}
-
-func BenchmarkDeDupe_WithAttrs_Parallel(b *testing.B) {
-	buf := bytes.NewBuffer(nil)
-	handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
-
-	// Pre-fill the attribute to be used in the benchmark
-	attr := slog.String("key", "value")
-
-	// Run benchmark with parallelism
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
+		// Benchmark logging with deduplication and attribute handling
+		for range b.N {
 			// Use the logger's Info method to log with attributes
 			handler.Info("test", attr)
 		}
+	})
+
+	b.Run("WithAttr Parallel", func(b *testing.B) {
+		buf := bytes.NewBuffer(nil)
+		handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+
+		// Pre-fill the attribute to be used in the benchmark
+		attr := slog.String("key", "value")
+
+		// Run benchmark with parallelism
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				// Use the logger's Info method to log with attributes
+				handler.Info("test", attr)
+			}
+		})
+	})
+
+	b.Run("Handle", func(b *testing.B) {
+		// Set up the buffer and logger
+		buf := bytes.NewBuffer(nil)
+		handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+
+		// Prepare the record to log
+		record := slog.NewRecord(
+			time.Now().UTC(),
+			slog.LevelInfo,
+			"test",
+			0,
+		)
+
+		// Reset the timer to exclude setup time from benchmarking
+		b.ResetTimer()
+
+		// Benchmark logging with deduplication by calling the handler's Handle method
+		for range b.N {
+			err := handler.Handler().Handle(context.Background(), record)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("Handle Parallel", func(b *testing.B) {
+		buf := bytes.NewBuffer(nil)
+		handler := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+
+		// Pre-fill the record to be logged in the benchmark
+		record := slog.NewRecord(time.Now().UTC(), slog.LevelInfo, "test", 0)
+
+		// Run benchmark with parallelism
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				err := handler.Handler().Handle(context.Background(), record)
+				if err != nil {
+					b.Errorf("failed to handle log record: %v", err)
+				}
+			}
+		})
 	})
 }

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 )
 
+// NewLogger creates a new logger with the default configuration.
 func NewLogger(opts ...Option) *slog.Logger {
 	return NewLoggerWithWriter(os.Stdout, opts...)
 }
 
+// NewLoggerWithWriter creates a new logger with the given writer and options.
 func NewLoggerWithWriter(writer io.Writer, opts ...Option) *slog.Logger {
 	logCfg := newLoggingConfig()
 
@@ -27,6 +29,7 @@ func NewLoggerWithWriter(writer io.Writer, opts ...Option) *slog.Logger {
 	return l
 }
 
+// LoggerWithComponent returns a new logger with the given component name.
 func LoggerWithComponent(l *slog.Logger, component string) *slog.Logger {
 	return l.With(
 		slog.String(KeyComponent, component),
@@ -34,7 +37,7 @@ func LoggerWithComponent(l *slog.Logger, component string) *slog.Logger {
 }
 
 // replaceAttrs is a slog.HandlerOptions.ReplaceAttr function that replaces some attributes.
-func replaceAttrs(_ []string, a slog.Attr) slog.Attr {
+func replaceAttrs(groups []string, a slog.Attr) slog.Attr {
 	if a.Key == slog.SourceKey {
 		// Cut the source file to a relative path.
 		v := strings.Split(a.Value.String(), "/")

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -124,7 +124,7 @@ func BenchmarkReplaceAttrs(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				replaceAttrs(nil, bm.attr)
 			}
 		})

--- a/options.go
+++ b/options.go
@@ -302,6 +302,15 @@ func WithIndefiniteAsyncTask(name string, fn AsyncTaskFunc) StartOption {
 	}
 }
 
+// WithFixedHashBucket is a StartOption that sets up the fixed hash bucket.
+func WithFixedHashBucket(size uint) StartOption {
+	return func(a *App) error {
+		hb := cache.NewFixedHashBucket(size)
+		a.fixedHashBucket = hb
+		return nil
+	}
+}
+
 // WithServiceEndpointHashBucket is a StartOption that sets up the service endpoint hash bucket.
 func WithServiceEndpointHashBucket(appName string) StartOption {
 	return func(a *App) error {

--- a/utils/kubernetes.go
+++ b/utils/kubernetes.go
@@ -12,7 +12,19 @@ const (
 
 // PodName returns the name of the pod. By default, Kubernetes sets the pod name as the HOSTNAME environment variable.
 var PodName = sync.OnceValue(func() string {
-	return os.Getenv("HOSTNAME")
+	hostname, err := os.Hostname()
+	if err == nil {
+		return hostname
+	}
+
+	// Attempt to read the pod name from the environment variable
+	hostname = os.Getenv("HOSTNAME")
+	if hostname != "" {
+		return hostname
+	}
+
+	// Fallback to an empty string if both methods fail
+	return ""
 })
 
 // DeployedNamespace returns the namespace in which the pod is deployed. This is read from the Kubernetes namespace file.


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes focused on improving error handling, introducing new utility classes, enhancing logging functionality, and refining Kubernetes-related utilities. Below is a categorized summary of the most important changes:

### Error Handling Improvements
* Enhanced error handling in the `Start` method of the `App` struct by replacing log-based error reporting with explicit error propagation for server and async task initialization issues. (`app.go`, [app.goR203-R245](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR203-R245))
* Added a new test case to validate error handling for invalid async task functions in `TestApp_Start`. (`app_test.go`, [app_test.goL304-R326](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL304-R326))

### New Utility Classes
* Introduced `FixedHashBucket` in the `cache` package, implementing a consistent hashing mechanism for bucket indexing. Includes methods for checking key membership, advancing the bucket index, and retrieving bucket properties. (`cache/fixed_hash_bucket.go`, [cache/fixed_hash_bucket.goR1-R51](diffhunk://#diff-2687a439f7145a5ba37793ba16c56c7900137ca8126ad69e74147a4b7796bf26R1-R51))
* Added comprehensive tests for `FixedHashBucket` to validate its functionality, including key distribution and index wrapping. (`cache/fixed_hash_bucket_test.go`, [cache/fixed_hash_bucket_test.goR1-R25](diffhunk://#diff-7047c9033a2f1630a984f71649a206af5e0cd821cf59673f74a91e14ea748f77R1-R25))

### Logging Enhancements
* Implemented `dedupeHandler`, a new `slog.Handler` that deduplicates log attributes. Includes methods for deduplication, grouping, and immutability. (`logging/dedupe_handler.go`, [logging/dedupe_handler.goR8-R26](diffhunk://#diff-5060370d65295a9a13abd32f75b5f91f5bb1cc2090f1f58efec4012e2dcd1600R8-R26))
* Added unit tests for `dedupeHandler` to ensure correct deduplication, grouping, and record handling. (`logging/dedupe_handler_bench_test.go`, [logging/dedupe_handler_bench_test.goL13-R134](diffhunk://#diff-13fb1392a0305950517660f9e96f7470268c46b3620fe4f1364902db9bbcebe0L13-R134))
* Improved `replaceAttrs` in `logging/logger.go` to handle attribute replacement more robustly, including new tests and benchmarks. (`logging/logger.go`, [[1]](diffhunk://#diff-19a22ab34725dc99b85cb111a4815502ed019f775ee0c19acdee7e0d1337febbR10-R15); `logging/logger_test.go`, [[2]](diffhunk://#diff-592d08cada4c87bd69e20d3eb1ac3b8d11c5482053528d03dd511611dcc9e517R52-R132)

### Kubernetes Utility Updates
* Refined the `PodName` utility to retrieve the pod name using `os.Hostname()` as the primary method and falling back to the `HOSTNAME` environment variable. Added a fallback to an empty string if both methods fail. (`utils/kubernetes.go`, [utils/kubernetes.goL15-R27](diffhunk://#diff-5e7387579e5df0711104e929cb2cef097f39418c8fbb6a7bb1261f416769f5a5L15-R27))

### Minor Improvements
* Added a `Shutdown` method to `ServiceEndpointHashBucket` for cleaning up resources. (`cache/service_endpoint_hash_bucket.go`, [cache/service_endpoint_hash_bucket.goR147](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9R147))
* Added interface compliance checks for `HashBucket` and `slog.Handler` implementations to ensure type safety. (`cache/service_endpoint_hash_bucket.go`, [[1]](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9R20-R21); `logging/dedupe_handler.go`, [[2]](diffhunk://#diff-5060370d65295a9a13abd32f75b5f91f5bb1cc2090f1f58efec4012e2dcd1600R8-R26)