### PR TITLE
feat(metrics): adding metric instrumentors with a wrap handler

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,21 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// WrapHandler wraps a http.HandlerFunc with the provided middlewares.
+// The execution order of the middlewares is the inverse of the parameter declaration.
+// This means that the first middleware in the list will be executed last.
+func WrapHandler(handler http.HandlerFunc, middlewares ...mux.MiddlewareFunc) http.Handler {
+	var wrappedHandler http.Handler = handler
+	for _, middleware := range middlewares {
+		if middleware == nil {
+			continue
+		}
+		wrappedHandler = middleware(wrappedHandler)
+	}
+	return wrappedHandler
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,101 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no middleware", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}
+
+		wrapped := WrapHandler(handler)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		wrapped.ServeHTTP(rr, req)
+		require.True(t, called, "handler should be called")
+	})
+
+	t.Run("single middleware", func(t *testing.T) {
+		t.Parallel()
+
+		handlerCalled := false
+		middlewareCalled := false
+
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			handlerCalled = true
+		}
+
+		middleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				middlewareCalled = true
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		wrapped := WrapHandler(handler, middleware)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		wrapped.ServeHTTP(rr, req)
+		require.True(t, handlerCalled, "handler should be called")
+		require.True(t, middlewareCalled, "middleware should be called")
+	})
+
+	t.Run("multiple middlewares execution order", func(t *testing.T) {
+		t.Parallel()
+
+		order := make([]int, 0, 3)
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, 0)
+		}
+
+		middleware1 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				order = append(order, 1)
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		middleware2 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				order = append(order, 2)
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		wrapped := WrapHandler(handler, middleware1, middleware2)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		wrapped.ServeHTTP(rr, req)
+		require.Equal(t, []int{2, 1, 0}, order, "middleware execution order should be reversed")
+	})
+
+	t.Run("nil middleware", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}
+
+		wrapped := WrapHandler(handler, nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		wrapped.ServeHTTP(rr, req)
+		require.True(t, called, "handler should be called even with nil middleware")
+	})
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -20,7 +20,7 @@ func TestWrapHandler(t *testing.T) {
 		}
 
 		wrapped := WrapHandler(handler)
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 		rr := httptest.NewRecorder()
 
 		wrapped.ServeHTTP(rr, req)
@@ -45,7 +45,7 @@ func TestWrapHandler(t *testing.T) {
 		}
 
 		wrapped := WrapHandler(handler, middleware)
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 		rr := httptest.NewRecorder()
 
 		wrapped.ServeHTTP(rr, req)
@@ -76,7 +76,7 @@ func TestWrapHandler(t *testing.T) {
 		}
 
 		wrapped := WrapHandler(handler, middleware1, middleware2)
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 		rr := httptest.NewRecorder()
 
 		wrapped.ServeHTTP(rr, req)
@@ -92,7 +92,7 @@ func TestWrapHandler(t *testing.T) {
 		}
 
 		wrapped := WrapHandler(handler, nil)
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 		rr := httptest.NewRecorder()
 
 		wrapped.ServeHTTP(rr, req)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// InstrumentDuration instruments a handler with the request duration, updating the supplied histogram.
+func InstrumentDuration(metric *prometheus.HistogramVec, options ...promhttp.Option) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return promhttp.InstrumentHandlerDuration(metric, next, options...)
+	}
+}
+
+// InstrumentCounter instruments a handler with the request counter, updating the supplied counter.
+func InstrumentCounter(metric *prometheus.CounterVec, options ...promhttp.Option) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return promhttp.InstrumentHandlerCounter(metric, next, options...)
+	}
+}
+
+// InstrumentRequestSize instruments a handler with the request size, updating the supplied histogram.
+func InstrumentRequestSize(metric *prometheus.HistogramVec, options ...promhttp.Option) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return promhttp.InstrumentHandlerRequestSize(metric, next, options...)
+	}
+}
+
+// InstrumentResponseSize instruments a handler with the response size, updating the supplied histogram.
+func InstrumentResponseSize(metric *prometheus.HistogramVec, options ...promhttp.Option) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return promhttp.InstrumentHandlerResponseSize(metric, next, options...)
+	}
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -27,7 +27,7 @@ func TestInstrumentDuration(t *testing.T) {
 	middleware := InstrumentDuration(metric)
 	wrapped := middleware(handler)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	rr := httptest.NewRecorder()
 
 	wrapped.ServeHTTP(rr, req)
@@ -56,7 +56,7 @@ func TestInstrumentCounter(t *testing.T) {
 	middleware := InstrumentCounter(metric)
 	wrapped := middleware(handler)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	rr := httptest.NewRecorder()
 
 	wrapped.ServeHTTP(rr, req)
@@ -85,7 +85,7 @@ func TestInstrumentRequestSize(t *testing.T) {
 	middleware := InstrumentRequestSize(metric)
 	wrapped := middleware(handler)
 
-	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 	req.Header.Set("Content-Length", "100")
 	rr := httptest.NewRecorder()
 
@@ -109,14 +109,13 @@ func TestInstrumentResponseSize(t *testing.T) {
 	)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := w.Write([]byte("test response"))
-		require.NoError(t, err)
+		_, _ = w.Write([]byte("test response"))
 	})
 
 	middleware := InstrumentResponseSize(metric)
 	wrapped := middleware(handler)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	rr := httptest.NewRecorder()
 
 	wrapped.ServeHTTP(rr, req)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,129 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstrumentDuration(t *testing.T) {
+	t.Parallel()
+
+	metric := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "test_duration_seconds",
+			Help: "Test duration in seconds",
+		},
+		[]string{"code", "method"},
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := InstrumentDuration(metric)
+	wrapped := middleware(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	metricCh := make(chan prometheus.Metric, 1)
+	metric.Collect(metricCh)
+	require.NotNil(t, <-metricCh, "metric should be collected")
+}
+
+func TestInstrumentCounter(t *testing.T) {
+	t.Parallel()
+
+	metric := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "test_requests_total",
+			Help: "Test request counter",
+		},
+		[]string{"code", "method"},
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := InstrumentCounter(metric)
+	wrapped := middleware(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	metricCh := make(chan prometheus.Metric, 1)
+	metric.Collect(metricCh)
+	require.NotNil(t, <-metricCh, "metric should be collected")
+}
+
+func TestInstrumentRequestSize(t *testing.T) {
+	t.Parallel()
+
+	metric := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "test_request_size_bytes",
+			Help: "Test request size in bytes",
+		},
+		[]string{"code", "method"},
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := InstrumentRequestSize(metric)
+	wrapped := middleware(handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Content-Length", "100")
+	rr := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	metricCh := make(chan prometheus.Metric, 1)
+	metric.Collect(metricCh)
+	require.NotNil(t, <-metricCh, "metric should be collected")
+}
+
+func TestInstrumentResponseSize(t *testing.T) {
+	t.Parallel()
+
+	metric := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "test_response_size_bytes",
+			Help: "Test response size in bytes",
+		},
+		[]string{"code", "method"},
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("test response"))
+		require.NoError(t, err)
+	})
+
+	middleware := InstrumentResponseSize(metric)
+	wrapped := middleware(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "test response", rr.Body.String())
+
+	metricCh := make(chan prometheus.Metric, 1)
+	metric.Collect(metricCh)
+	require.NotNil(t, <-metricCh, "metric should be collected")
+}

--- a/utils/commit.go
+++ b/utils/commit.go
@@ -58,11 +58,7 @@ var IsModified = sync.OnceValue(func() bool {
 				continue
 			}
 
-			containsChanges, err := strconv.ParseBool(setting.Value)
-			if err != nil {
-				return false
-			}
-
+			containsChanges, _ := strconv.ParseBool(setting.Value)
 			return containsChanges
 		}
 	}

--- a/utils/commit.go
+++ b/utils/commit.go
@@ -60,7 +60,6 @@ var IsModified = sync.OnceValue(func() bool {
 
 			containsChanges, err := strconv.ParseBool(setting.Value)
 			if err != nil {
-				// Log or handle the error as needed. Defaulting to false for invalid values.
 				return false
 			}
 			return containsChanges

--- a/utils/commit.go
+++ b/utils/commit.go
@@ -58,7 +58,11 @@ var IsModified = sync.OnceValue(func() bool {
 				continue
 			}
 
-			containsChanges, _ := strconv.ParseBool(setting.Value)
+			containsChanges, err := strconv.ParseBool(setting.Value)
+			if err != nil {
+				// Log or handle the error as needed. Defaulting to false for invalid values.
+				return false
+			}
 			return containsChanges
 		}
 	}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces middleware utilities for wrapping HTTP handlers and instrumentation for Prometheus metrics, along with corresponding unit tests. Additionally, it includes a minor simplification in error handling logic in the `utils/commit.go` file.

### Middleware Utilities

* Added a `WrapHandler` function in `handlers.go` to wrap HTTP handlers with a chain of middlewares, ensuring the first middleware in the list is executed last.
* Added unit tests in `handlers_test.go` to validate `WrapHandler` functionality, including cases for no middleware, a single middleware, multiple middlewares (execution order), and handling of `nil` middleware.

### Prometheus Instrumentation

* Introduced middleware functions in `metrics/metrics.go` for Prometheus instrumentation, including `InstrumentDuration`, `InstrumentCounter`, `InstrumentRequestSize`, and `InstrumentResponseSize`, to measure request/response metrics.
* Added corresponding unit tests in `metrics/metrics_test.go` to ensure the correctness of each instrumentation middleware, verifying metric collection and behavior.

### Code Simplification

* Simplified error handling in `utils/commit.go` by removing explicit error checking for `strconv.ParseBool` in the `IsModified` function.