### PR TITLE
feat(health): adding the handling for the error grace period

### DIFF
--- a/health/check_options.go
+++ b/health/check_options.go
@@ -26,9 +26,9 @@ func WithNoCheckTimeout() CheckOption {
 }
 
 // WithCheckErrorGracePeriod sets the maximum time the check can be in an error state before it is marked as down.
-func WithCheckErrorGracePeriod(maxTimeInError time.Duration) CheckOption {
+func WithCheckErrorGracePeriod(errorGracePeriod time.Duration) CheckOption {
 	return func(c *Check) {
-		c.maxTimeInError = maxTimeInError
+		c.errorGracePeriod = errorGracePeriod
 	}
 }
 

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -58,12 +58,13 @@ func TestCheck_Check_Golden_FailCheck(t *testing.T) {
 	require.EqualError(t, err, "test error")
 
 	expectedState := &State{
-		lastCheckTime:   now,
-		lastSuccess:     time.Time{},
-		lastFail:        now,
-		contiguousFails: 1,
-		checkErr:        errors.New("test error"),
-		status:          StatusDown,
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  1,
+		checkErr:         errors.New("test error"),
+		status:           StatusDown,
+		firstFailInCycle: now,
 	}
 	require.Equal(t, expectedState, c.state)
 	require.True(t, statusListenerCalled)
@@ -98,12 +99,13 @@ func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
 	require.NoError(t, err, "First Check() should not return an error")
 
 	expectedState := &State{
-		lastCheckTime:   now,
-		lastSuccess:     now,
-		lastFail:        time.Time{},
-		contiguousFails: 0,
-		checkErr:        nil,
-		status:          StatusUp,
+		lastCheckTime:    now,
+		lastSuccess:      now,
+		lastFail:         time.Time{},
+		contiguousFails:  0,
+		checkErr:         nil,
+		status:           StatusUp,
+		firstFailInCycle: time.Time{},
 	}
 	require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
 
@@ -111,12 +113,13 @@ func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
 	require.EqualError(t, err, "test error", "Second Check() should return the correct error")
 
 	expectedState = &State{
-		lastCheckTime:   now,
-		lastSuccess:     now,
-		lastFail:        now,
-		contiguousFails: 1,
-		checkErr:        errors.New("test error"),
-		status:          StatusDown,
+		lastCheckTime:    now,
+		lastSuccess:      now,
+		lastFail:         now,
+		contiguousFails:  1,
+		checkErr:         errors.New("test error"),
+		status:           StatusDown,
+		firstFailInCycle: now,
 	}
 	require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
 
@@ -124,12 +127,13 @@ func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
 	require.NoError(t, err, "Third Check() should not return an error")
 
 	expectedState = &State{
-		lastCheckTime:   now,
-		lastSuccess:     now,
-		lastFail:        now,
-		contiguousFails: 0,
-		checkErr:        nil,
-		status:          StatusUp,
+		lastCheckTime:    now,
+		lastSuccess:      now,
+		lastFail:         now,
+		contiguousFails:  0,
+		checkErr:         nil,
+		status:           StatusUp,
+		firstFailInCycle: time.Time{},
 	}
 	require.Equal(t, expectedState, c.state)
 	require.Equal(t, 3, statusListenerCalled)
@@ -160,12 +164,13 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 	require.EqualError(t, err, "test error", "First Check() should return the correct error")
 
 	expectedState := &State{
-		lastCheckTime:   now,
-		lastSuccess:     time.Time{},
-		lastFail:        now,
-		contiguousFails: 1,
-		checkErr:        errors.New("test error"),
-		status:          StatusUp,
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  1,
+		checkErr:         errors.New("test error"),
+		status:           StatusUp,
+		firstFailInCycle: now,
 	}
 	require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
 	require.Equal(t, 1, statusListenerCalled)
@@ -174,12 +179,13 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 	require.EqualError(t, err, "test error", "Second Check() should return the correct error")
 
 	expectedState = &State{
-		lastCheckTime:   now,
-		lastSuccess:     time.Time{},
-		lastFail:        now,
-		contiguousFails: 2,
-		checkErr:        errors.New("test error"),
-		status:          StatusUp,
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  2,
+		checkErr:         errors.New("test error"),
+		status:           StatusUp,
+		firstFailInCycle: now,
 	}
 	require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
 	require.Equal(t, 1, statusListenerCalled)
@@ -188,12 +194,13 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 	require.EqualError(t, err, "test error", "Third Check() should return the correct error")
 
 	expectedState = &State{
-		lastCheckTime:   now,
-		lastSuccess:     time.Time{},
-		lastFail:        now,
-		contiguousFails: 3,
-		checkErr:        errors.New("test error"),
-		status:          StatusDown,
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  3,
+		checkErr:         errors.New("test error"),
+		status:           StatusDown,
+		firstFailInCycle: now,
 	}
 	require.Equal(t, expectedState, c.state, "Third Check() should update the state correctly")
 	require.Equal(t, 2, statusListenerCalled)
@@ -202,12 +209,13 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 	require.EqualError(t, err, "test error", "Fourth Check() should return the correct error")
 
 	expectedState = &State{
-		lastCheckTime:   now,
-		lastSuccess:     time.Time{},
-		lastFail:        now,
-		contiguousFails: 4,
-		checkErr:        errors.New("test error"),
-		status:          StatusDown,
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  4,
+		checkErr:         errors.New("test error"),
+		status:           StatusDown,
+		firstFailInCycle: now,
 	}
 	require.Equal(t, expectedState, c.state, "Fourth Check() should update the state correctly")
 	require.Equal(t, 2, statusListenerCalled)
@@ -225,12 +233,13 @@ func TestCheck_StatusError(t *testing.T) {
 	require.EqualError(t, err, "test error")
 
 	expectedState := &State{
-		lastCheckTime:   now,
-		lastSuccess:     time.Time{},
-		lastFail:        now,
-		contiguousFails: 1,
-		checkErr:        NewStatusError(errors.New("test error"), StatusDegraded),
-		status:          StatusDegraded,
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  1,
+		checkErr:         NewStatusError(errors.New("test error"), StatusDegraded),
+		status:           StatusDegraded,
+		firstFailInCycle: now,
 	}
 	require.Equal(t, expectedState, c.state)
 }
@@ -294,4 +303,97 @@ func TestCheck_NoParentContext(t *testing.T) {
 	}
 	require.Equal(t, expectedState, c.state)
 	require.True(t, statusListenerCalled)
+}
+
+func TestCheck_ErrorGracePeriod(t *testing.T) {
+	var currentTime time.Time
+	timestamp = func() time.Time { return currentTime }
+
+	statusChanges := make([]Status, 0)
+	c := NewCheck("test",
+		func(ctx context.Context) error {
+			return errors.New("test error")
+		},
+		WithCheckErrorGracePeriod(5*time.Second),
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+			statusChanges = append(statusChanges, state.status)
+		}),
+	)
+
+	// Start at t=0
+	currentTime = time.Unix(0, 0)
+	err := c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period")
+	require.Equal(t, currentTime, c.state.lastFail)
+
+	// Check at t=3s (within grace period)
+	currentTime = time.Unix(3, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should still be UP within grace period")
+	require.Equal(t, currentTime, c.state.lastFail)
+
+	// Check at t=6s (exceeds grace period)
+	currentTime = time.Unix(7, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
+	require.Equal(t, currentTime, c.state.lastFail)
+
+	// Verify status changes
+	require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
+
+	// Verify recovery
+	currentTime = time.Unix(9, 0)
+	c.check = func(ctx context.Context) error { return nil }
+	err = c.Check(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should recover to UP")
+	require.Equal(t, time.Unix(7, 0), c.state.lastFail, "lastFail should remain at last failure time")
+	require.Equal(t, []Status{StatusUp, StatusDown, StatusUp}, statusChanges)
+}
+
+func TestCheck_ErrorGracePeriod_WithMaxContiguousFails(t *testing.T) {
+	var currentTime time.Time
+	timestamp = func() time.Time { return currentTime }
+
+	statusChanges := make([]Status, 0)
+	c := NewCheck("test",
+		func(ctx context.Context) error {
+			return errors.New("test error")
+		},
+		WithCheckErrorGracePeriod(5*time.Second),
+		WithCheckMaxFailures(3),
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+			statusChanges = append(statusChanges, state.status)
+		}),
+	)
+
+	// Start at t=0
+	currentTime = time.Unix(0, 0)
+	err := c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
+
+	// Check at t=3s (failure 2)
+	currentTime = time.Unix(3, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
+
+	// Check at t=4s (failure 3)
+	currentTime = time.Unix(4, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period despite max failures")
+
+	// Check at t=6s (exceeds grace period)
+	currentTime = time.Unix(6, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
+
+	// Verify status changes
+	require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
 }

--- a/health/state.go
+++ b/health/state.go
@@ -13,6 +13,9 @@ type State struct {
 	// lastFail is the last time the check failed.
 	lastFail time.Time
 
+	// firstFailInCycle is the first time the check failed in the current cycle.
+	firstFailInCycle time.Time
+
 	// contiguousFails is the number of contiguous failures.
 	contiguousFails uint
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request improves the health check system by introducing an error grace period mechanism, refining state management, and enhancing test coverage. The most notable changes include replacing `maxTimeInError` with `errorGracePeriod`, updating the status determination logic to account for the grace period, and adding new tests to validate these changes.

### Updates to Health Check Logic:
* Replaced the `maxTimeInError` field with `errorGracePeriod` in the `Check` struct to represent the maximum time a check can remain in an error state before being marked as down. (`health/check.go`, [health/check.goL23-R24](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dL23-R24))
* Updated the `Check` method to incorporate the error grace period when determining the check's status, ensuring it remains `StatusUp` within the grace period or the maximum contiguous failures threshold. (`health/check.go`, [health/check.goL92-R124](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dL92-R124))

### State Management Enhancements:
* Added a new `firstFailInCycle` field in the `State` struct to track the timestamp of the first failure in the current cycle, enabling accurate grace period calculations. (`health/state.go`, [health/state.goR16-R18](diffhunk://#diff-f61fb254e0f31d74ad9b263d11b4ecfbe06610ad869e1baeb8b379d8c72e7132R16-R18))

### Test Suite Improvements:
* Updated existing tests (e.g., `TestCheck_Check_Golden_*`) to validate the inclusion of `firstFailInCycle` in the state. (`health/check_test.go`, [[1]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R67) [[2]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R108) [[3]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R122) [[4]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R136) [[5]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R173) [[6]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R188) [[7]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R203) [[8]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R218) [[9]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R242)
* Added new tests, `TestCheck_ErrorGracePeriod` and `TestCheck_ErrorGracePeriod_WithMaxContiguousFails`, to verify the behavior of the error grace period under various conditions, including interactions with the maximum contiguous failures setting. (`health/check_test.go`, [health/check_test.goR307-R399](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1R307-R399))

### API Changes:
* Renamed the `WithCheckErrorGracePeriod` option parameter from `maxTimeInError` to `errorGracePeriod` for consistency with the new field name. (`health/check_options.go`, [health/check_options.goL29-R31](diffhunk://#diff-da6e34d615c9bcd2a3a764e7e0664a0b5e7f8fcddc82f2e6f3fa7fc1520455dfL29-R31))