### PR TITLE
feat(app): small retructure and tidy

### DIFF
--- a/app.go
+++ b/app.go
@@ -18,7 +18,7 @@ import (
 	"github.com/jacobbrewer1/vaulty/vsql"
 	"github.com/jacobbrewer1/web/cache"
 	"github.com/jacobbrewer1/web/logging"
-	"github.com/jacobbrewer1/web/utils"
+	"github.com/jacobbrewer1/web/version"
 	"github.com/jacobbrewer1/workerpool"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -178,9 +178,9 @@ func (a *App) Start(opts ...StartOption) error {
 		defer close(a.isStartedChan)
 
 		a.l.Info("starting application",
-			slog.String(logging.KeyGitCommit, utils.GitCommit()),
+			slog.String(logging.KeyGitCommit, version.GitCommit()),
 			slog.String(logging.KeyRuntime, fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)),
-			slog.String(logging.KeyBuildDate, utils.CommitTimestamp().String()),
+			slog.String(logging.KeyBuildDate, version.CommitTimestamp().String()),
 		)
 
 		for _, opt := range opts {

--- a/k8s/pod.go
+++ b/k8s/pod.go
@@ -1,37 +1,122 @@
 package k8s
 
 import (
+	"net"
 	"os"
+	"strings"
 	"sync"
 )
 
 const (
-	// kubeNamespacePath is the path to the Kubernetes namespace file
-	kubernetesNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	// kubernetesServiceAccountPath is the path to the Kubernetes service account file
+	kubernetesServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+
+	// kubernetesNamespacePath is the path to the Kubernetes namespace file
+	kubernetesNamespacePath = kubernetesServiceAccountPath + "/namespace"
+
+	// kubernetesServiceAccountTokenPath is the path to the Kubernetes service account token file
+	kubernetesServiceAccountTokenPath = kubernetesServiceAccountPath + "/token"
 )
 
-// PodName returns the name of the pod. By default, Kubernetes sets the pod name as the HOSTNAME environment variable.
-var PodName = sync.OnceValue(func() string {
-	hostname, err := os.Hostname()
-	if err == nil {
-		return hostname
-	}
+const (
+	envHostname           = "HOSTNAME"
+	envPodIP              = "POD_IP"
+	envServiceAccountName = "SERVICE_ACCOUNT_NAME"
+	envKubernetesHost     = "KUBERNETES_SERVICE_HOST"
+	envKubernetesPort     = "KUBERNETES_SERVICE_PORT"
+	envNodeName           = "NODE_NAME"
+)
 
-	// Attempt to read the pod name from the environment variable
-	hostname = os.Getenv("HOSTNAME")
-	if hostname != "" {
-		return hostname
-	}
+var (
+	// PodName returns the name of the pod. By default, Kubernetes sets the pod name as the HOSTNAME environment variable.
+	PodName = sync.OnceValue(func() string {
+		hostname, err := os.Hostname()
+		if err == nil {
+			return hostname
+		}
 
-	// Fallback to an empty string if both methods fail
-	return ""
-})
+		// Attempt to read the pod name from the environment variable
+		hostname = os.Getenv(envHostname)
+		if hostname != "" {
+			return hostname
+		}
 
-// DeployedNamespace returns the namespace in which the pod is deployed. This is read from the Kubernetes namespace file.
-var DeployedNamespace = sync.OnceValue(func() string {
-	got, err := os.ReadFile(kubernetesNamespacePath)
-	if err != nil {
-		return "default" // Fallback to default namespace if the file is not found
-	}
-	return string(got)
-})
+		// Fallback to an empty string if both methods fail
+		return ""
+	})
+
+	// PodIP returns the IP address of the pod. This is read from the environment variable POD_IP.
+	PodIP = sync.OnceValue(func() string {
+		podIP := os.Getenv(envPodIP)
+		if podIP != "" {
+			return podIP
+		}
+
+		// Fallback to an empty string if the environment variable is not set
+		return ""
+	})
+
+	// NodeName returns the name of the node on which the pod is running.
+	NodeName = sync.OnceValue(func() string {
+		nodeName := os.Getenv(envNodeName)
+		if nodeName != "" {
+			return nodeName
+		}
+
+		// Fallback to an empty string if the environment variable is not set
+		return ""
+	})
+)
+
+var (
+	// DeployedNamespace returns the namespace in which the pod is deployed. This is read from the Kubernetes namespace file.
+	DeployedNamespace = sync.OnceValue(func() string {
+		got, err := os.ReadFile(kubernetesNamespacePath)
+		if err != nil {
+			return "default" // Fallback to default namespace if the file is not found
+		}
+		return strings.TrimSpace(string(got))
+	})
+
+	// IsInCluster checks if the code is running inside a Kubernetes cluster by checking the existence of the service account file.
+	IsInCluster = sync.OnceValue(func() bool {
+		_, err := os.Stat(kubernetesNamespacePath)
+		return err == nil
+	})
+
+	// KubernetesService returns the full address (host:port) of the Kubernetes service.
+	// These are read from environment variables with fallback to localhost:443.
+	KubernetesService = sync.OnceValue(func() string {
+		host := os.Getenv(envKubernetesHost)
+		if host == "" {
+			host = "localhost"
+		}
+
+		port := os.Getenv(envKubernetesPort)
+		if port == "" {
+			port = "443"
+		}
+		return net.JoinHostPort(host, port)
+	})
+)
+
+var (
+	// ServiceAccountName returns the name of the service account used by the pod. This is read from the Kubernetes service account file.
+	ServiceAccountName = sync.OnceValue(func() string {
+		serviceAccountName := os.Getenv(envServiceAccountName)
+		if serviceAccountName != "" {
+			return serviceAccountName
+		}
+
+		return "default" // Fallback to default service account if the environment variable is not set
+	})
+
+	// ServiceAccountToken returns the token used by the service account. This is read from the Kubernetes service account file.
+	ServiceAccountToken = sync.OnceValue(func() string {
+		got, err := os.ReadFile(kubernetesServiceAccountTokenPath)
+		if err != nil {
+			return "" // Token file not found or not readable
+		}
+		return strings.TrimSpace(string(got))
+	})
+)

--- a/k8s/pod.go
+++ b/k8s/pod.go
@@ -1,4 +1,4 @@
-package utils
+package k8s
 
 import (
 	"os"

--- a/version/info.go
+++ b/version/info.go
@@ -1,4 +1,4 @@
-package utils
+package version
 
 import (
 	"runtime/debug"


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces several updates to improve code organization and functionality. Key changes include the migration of utility functions to more specific packages (`k8s` and `version`), updates to the logging and leader election logic, and enhancements to the health check and JetStream stream creation logic.

### Code Organization and Refactoring:
* Renamed `utils/kubernetes.go` to `k8s/pod.go` and updated its package to `k8s`. All references to Kubernetes-related utility functions (e.g., `PodName`, `DeployedNamespace`) were updated to use the `k8s` package. (`[[1]](diffhunk://#diff-e8467820f51928f4eb415288a20a1152d32a373fd162fef95a764ae1f91f9f67L1-R1)`, `[[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L156-R156)`, `[[3]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L173-R177)`, `[[4]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L325-R330)`)
* Renamed `utils/commit.go` to `version/info.go` and updated its package to `version`. Logging functions now use `version.GitCommit` and `version.CommitTimestamp` instead of `utils` equivalents. (`[[1]](diffhunk://#diff-34ed63292cac5bb2ffb8e16475dabef05eab90ff8610494462db028eaa14a9efL1-R1)`, `[[2]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL21-R21)`, `[[3]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL181-R183)`)

### Logging Enhancements:
* Updated logging in the `Start` method of `app.go` to reflect the migration of commit information utilities to the `version` package. (`[app.goL181-R183](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL181-R183)`)

### Health Check Improvements:
* Added a check in `WithHealthCheck` to prevent registering multiple health check servers. If a health check server is already registered, an error is returned. (`[options.goR216-R219](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R216-R219)`)

### JetStream Stream Creation:
* Replaced `CreateStream` with `CreateOrUpdateStream` in the `WithNatsJetStream` function to allow updating an existing stream if it already exists. (`[options.goL368-R372](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L368-R372)`)