### PR TITLE
chore(mutex): Using the proper mutex where required

### DIFF
--- a/cache/service_endpoint_hash_bucket_test.go
+++ b/cache/service_endpoint_hash_bucket_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -96,7 +97,8 @@ func Test_onEndpointUpdate(t *testing.T) {
 	t.Parallel()
 
 	sb := &ServiceEndpointHashBucket{
-		l: slog.New(slog.DiscardHandler),
+		mut: new(sync.RWMutex),
+		l:   slog.New(slog.DiscardHandler),
 		hr: hashring.New([]string{
 			"a",
 			"b",
@@ -193,4 +195,18 @@ func Test_endpointsToSet(t *testing.T) {
 			},
 		),
 	)
+}
+
+func Test_InBucket_WithoutStart(t *testing.T) {
+	t.Parallel()
+
+	sb := NewServiceEndpointHashBucket(
+		slog.New(slog.DiscardHandler),
+		fake.NewClientset(),
+		"my-svc",
+		"my-ns",
+		"pod-1",
+	)
+
+	require.False(t, sb.InBucket("key"), "should not be in bucket before starting")
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces changes to improve concurrency handling by replacing `sync.Mutex` with `sync.RWMutex` in two key components: `ServiceEndpointHashBucket` and `Set`. It also adds a new test case to ensure proper behavior when `InBucket` is called before initialization.

### Concurrency Improvements

* [`cache/service_endpoint_hash_bucket.go`](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9L25-R25): Replaced `sync.Mutex` with `sync.RWMutex` in `ServiceEndpointHashBucket` to allow concurrent read operations. Updated the `InBucket` method to use `RLock`/`RUnlock` and added a check for uninitialized hash rings with an appropriate error log. (`[[1]](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9L25-R25)`, `[[2]](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9L82-R89)`)
* [`slices/set.go`](diffhunk://#diff-98742020d79482b24f3dbdb3e075e3856563d29dc5dcf198e2f1b6c1cdc48a22L9-R16): Replaced `sync.Mutex` with `sync.RWMutex` in `Set` to improve performance by enabling concurrent reads. Updated methods like `Contains`, `Difference`, `Union`, `Each`, and `Items` to use `RLock`/`RUnlock` for read operations. (`[[1]](diffhunk://#diff-98742020d79482b24f3dbdb3e075e3856563d29dc5dcf198e2f1b6c1cdc48a22L9-R16)`, `[[2]](diffhunk://#diff-98742020d79482b24f3dbdb3e075e3856563d29dc5dcf198e2f1b6c1cdc48a22L41-R55)`, `[[3]](diffhunk://#diff-98742020d79482b24f3dbdb3e075e3856563d29dc5dcf198e2f1b6c1cdc48a22L67-R72)`, `[[4]](diffhunk://#diff-98742020d79482b24f3dbdb3e075e3856563d29dc5dcf198e2f1b6c1cdc48a22L85-R88)`, `[[5]](diffhunk://#diff-98742020d79482b24f3dbdb3e075e3856563d29dc5dcf198e2f1b6c1cdc48a22L95-R98)`)

### Test Enhancements

* [`cache/service_endpoint_hash_bucket_test.go`](diffhunk://#diff-a4c64fb14c304c0df4e42d6e0a4311cb19b1b542cf2be946a4f1d729ec2b7cbfR199-R212): Added a new test case, `Test_InBucket_WithoutStart`, to verify that calling `InBucket` before initialization returns `false` and logs an error. This ensures robust handling of uninitialized states. (`[cache/service_endpoint_hash_bucket_test.goR199-R212](diffhunk://#diff-a4c64fb14c304c0df4e42d6e0a4311cb19b1b542cf2be946a4f1d729ec2b7cbfR199-R212)`)