### PR TITLE
chore(health): using the atomic package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ max_line_length = 120
 tab_width = 4
 
 [{*.go,*.go2}]
+indent_style = tab
 ij_go_import_sorting = gofmt
 ij_go_local_group_mode = prefix
 ij_go_local_package_prefixes = github.com/jacobbrewer1

--- a/health/check.go
+++ b/health/check.go
@@ -1,9 +1,9 @@
 package health
 
 import (
-    "context"
-    "errors"
-    "time"
+	"context"
+	"errors"
+	"time"
 )
 
 // CheckFunc is a function that performs the check.
@@ -14,26 +14,26 @@ type StatusListenerFunc = func(ctx context.Context, name string, state *State)
 
 // Check is a struct that represents a health check.
 type Check struct {
-    // name is the name of the check.
-    name string
+	// name is the name of the check.
+	name string
 
-    // check is the function that performs the check.
-    check CheckFunc
+	// check is the function that performs the check.
+	check CheckFunc
 
-    // timeout is the timeout for the check.
-    timeout time.Duration
+	// timeout is the timeout for the check.
+	timeout time.Duration
 
-    // errorGracePeriod is the maximum time the check can be in an error state.
-    errorGracePeriod time.Duration
+	// errorGracePeriod is the maximum time the check can be in an error state.
+	errorGracePeriod time.Duration
 
-    // maxContiguousFails is the maximum number of contiguous fails.
-    maxContiguousFails uint32
+	// maxContiguousFails is the maximum number of contiguous fails.
+	maxContiguousFails uint32
 
-    // statusListener is the function that will be called when the status changes.
-    statusListener StatusListenerFunc
+	// statusListener is the function that will be called when the status changes.
+	statusListener StatusListenerFunc
 
-    // state is the state of the check.
-    state *State
+	// state is the state of the check.
+	state *State
 }
 
 // NewCheck creates a new Check. Every check should have a unique name.
@@ -42,89 +42,89 @@ type Check struct {
 // checks that return a status other than up or down. For example, you can return a status of "degraded" if the check
 // is partially failing. This is useful for checks that are not binary in nature.
 func NewCheck(name string, checkerFunc CheckFunc, options ...CheckOption) *Check {
-    c := &Check{
-        name:    name,
-        check:   checkerFunc,
-        timeout: 5 * time.Second,
-        state:   NewState(),
-    }
+	c := &Check{
+		name:    name,
+		check:   checkerFunc,
+		timeout: 5 * time.Second,
+		state:   NewState(),
+	}
 
-    for _, option := range options {
-        option(c)
-    }
+	for _, option := range options {
+		option(c)
+	}
 
-    return c
+	return c
 }
 
 // String returns the name of the check.
 func (c *Check) String() string {
-    return c.name
+	return c.name
 }
 
 // Check performs the check and updates the state of the check.
 func (c *Check) Check(ctx context.Context) error {
-    if ctx == nil {
-        ctx = context.Background()
-    }
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-    now := timestamp()
-    c.state.lastCheckTime = now
+	now := timestamp()
+	c.state.lastCheckTime = now
 
-    var (
-        checkCtx context.Context
-        cancel   context.CancelFunc
-    )
-    if c.timeout > 0 {
-        checkCtx, cancel = context.WithTimeout(ctx, c.timeout)
-    } else {
-        checkCtx, cancel = context.WithCancel(ctx)
-    }
-    defer cancel()
+	var (
+		checkCtx context.Context
+		cancel   context.CancelFunc
+	)
+	if c.timeout > 0 {
+		checkCtx, cancel = context.WithTimeout(ctx, c.timeout)
+	} else {
+		checkCtx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
 
-    newStatus := StatusUnknown
-    defer func() {
-        if c.statusListener != nil && c.state.status != newStatus {
-            c.state.status = newStatus // Set the new status before calling the listener
-            c.statusListener(checkCtx, c.name, c.state)
-        } else {
-            c.state.status = newStatus
-        }
-    }()
+	newStatus := StatusUnknown
+	defer func() {
+		if c.statusListener != nil && c.state.status != newStatus {
+			c.state.status = newStatus // Set the new status before calling the listener
+			c.statusListener(checkCtx, c.name, c.state)
+		} else {
+			c.state.status = newStatus
+		}
+	}()
 
-    if err := c.check(checkCtx); err != nil {
-        c.state.contiguousFails.Add(1)
-        c.state.checkErr = err
-        c.state.lastFail = now
+	if err := c.check(checkCtx); err != nil {
+		c.state.contiguousFails.Add(1)
+		c.state.checkErr = err
+		c.state.lastFail = now
 
-        if c.state.firstFailInCycle.IsZero() {
-            c.state.firstFailInCycle = now
-        }
+		if c.state.firstFailInCycle.IsZero() {
+			c.state.firstFailInCycle = now
+		}
 
-        // Determine status based on grace period and contiguous fails
-        newStatus = StatusDown
-        if c.errorGracePeriod > 0 && now.Sub(c.state.firstFailInCycle) <= c.errorGracePeriod {
-            newStatus = StatusUp // Still within grace period
-        } else if c.maxContiguousFails > 0 && c.state.contiguousFails.Load() < c.maxContiguousFails {
-            newStatus = StatusUp // Still within fail threshold
-        }
+		// Determine status based on grace period and contiguous fails
+		newStatus = StatusDown
+		if c.errorGracePeriod > 0 && now.Sub(c.state.firstFailInCycle) <= c.errorGracePeriod {
+			newStatus = StatusUp // Still within grace period
+		} else if c.maxContiguousFails > 0 && c.state.contiguousFails.Load() < c.maxContiguousFails {
+			newStatus = StatusUp // Still within fail threshold
+		}
 
-        // Handle custom status errors
-        statusErr := new(StatusError)
-        if errors.As(err, &statusErr) {
-            if !statusErr.Status.IsValid() {
-                statusErr.Status = StatusUnknown
-            }
-            newStatus = statusErr.Status
-        }
+		// Handle custom status errors
+		statusErr := new(StatusError)
+		if errors.As(err, &statusErr) {
+			if !statusErr.Status.IsValid() {
+				statusErr.Status = StatusUnknown
+			}
+			newStatus = statusErr.Status
+		}
 
-        return err
-    }
+		return err
+	}
 
-    newStatus = StatusUp
-    c.state.lastSuccess = now
-    c.state.contiguousFails.Store(0)
-    c.state.checkErr = nil
-    c.state.firstFailInCycle = time.Time{}
+	newStatus = StatusUp
+	c.state.lastSuccess = now
+	c.state.contiguousFails.Store(0)
+	c.state.checkErr = nil
+	c.state.firstFailInCycle = time.Time{}
 
-    return nil
+	return nil
 }

--- a/health/check.go
+++ b/health/check.go
@@ -1,36 +1,39 @@
 package health
 
 import (
-	"context"
-	"errors"
-	"time"
+    "context"
+    "errors"
+    "time"
 )
 
 // CheckFunc is a function that performs the check.
 type CheckFunc = func(ctx context.Context) error
 
+// StatusListenerFunc is a function that is called when the status of the check changes.
+type StatusListenerFunc = func(ctx context.Context, name string, state *State)
+
 // Check is a struct that represents a health check.
 type Check struct {
-	// name is the name of the check.
-	name string
+    // name is the name of the check.
+    name string
 
-	// check is the function that performs the check.
-	check CheckFunc
+    // check is the function that performs the check.
+    check CheckFunc
 
-	// timeout is the timeout for the check.
-	timeout time.Duration
+    // timeout is the timeout for the check.
+    timeout time.Duration
 
-	// errorGracePeriod is the maximum time the check can be in an error state.
-	errorGracePeriod time.Duration
+    // errorGracePeriod is the maximum time the check can be in an error state.
+    errorGracePeriod time.Duration
 
-	// maxContiguousFails is the maximum number of contiguous fails.
-	maxContiguousFails uint
+    // maxContiguousFails is the maximum number of contiguous fails.
+    maxContiguousFails uint32
 
-	// statusListener is the function that will be called when the status changes.
-	statusListener func(ctx context.Context, name string, state State)
+    // statusListener is the function that will be called when the status changes.
+    statusListener StatusListenerFunc
 
-	// state is the state of the check.
-	state *State
+    // state is the state of the check.
+    state *State
 }
 
 // NewCheck creates a new Check. Every check should have a unique name.
@@ -39,89 +42,89 @@ type Check struct {
 // checks that return a status other than up or down. For example, you can return a status of "degraded" if the check
 // is partially failing. This is useful for checks that are not binary in nature.
 func NewCheck(name string, checkerFunc CheckFunc, options ...CheckOption) *Check {
-	c := &Check{
-		name:    name,
-		check:   checkerFunc,
-		timeout: 5 * time.Second,
-		state:   &State{status: StatusUnknown},
-	}
+    c := &Check{
+        name:    name,
+        check:   checkerFunc,
+        timeout: 5 * time.Second,
+        state:   NewState(),
+    }
 
-	for _, option := range options {
-		option(c)
-	}
+    for _, option := range options {
+        option(c)
+    }
 
-	return c
+    return c
 }
 
 // String returns the name of the check.
 func (c *Check) String() string {
-	return c.name
+    return c.name
 }
 
 // Check performs the check and updates the state of the check.
 func (c *Check) Check(ctx context.Context) error {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+    if ctx == nil {
+        ctx = context.Background()
+    }
 
-	now := timestamp()
-	c.state.lastCheckTime = now
+    now := timestamp()
+    c.state.lastCheckTime = now
 
-	var (
-		checkCtx context.Context
-		cancel   context.CancelFunc
-	)
-	if c.timeout > 0 {
-		checkCtx, cancel = context.WithTimeout(ctx, c.timeout)
-	} else {
-		checkCtx, cancel = context.WithCancel(ctx)
-	}
-	defer cancel()
+    var (
+        checkCtx context.Context
+        cancel   context.CancelFunc
+    )
+    if c.timeout > 0 {
+        checkCtx, cancel = context.WithTimeout(ctx, c.timeout)
+    } else {
+        checkCtx, cancel = context.WithCancel(ctx)
+    }
+    defer cancel()
 
-	newStatus := StatusUnknown
-	defer func() {
-		if c.statusListener != nil && c.state.status != newStatus {
-			c.state.status = newStatus // Set the new status before calling the listener
-			c.statusListener(checkCtx, c.name, *c.state)
-		} else {
-			c.state.status = newStatus
-		}
-	}()
+    newStatus := StatusUnknown
+    defer func() {
+        if c.statusListener != nil && c.state.status != newStatus {
+            c.state.status = newStatus // Set the new status before calling the listener
+            c.statusListener(checkCtx, c.name, c.state)
+        } else {
+            c.state.status = newStatus
+        }
+    }()
 
-	if err := c.check(checkCtx); err != nil {
-		c.state.contiguousFails++
-		c.state.checkErr = err
-		c.state.lastFail = now
+    if err := c.check(checkCtx); err != nil {
+        c.state.contiguousFails.Add(1)
+        c.state.checkErr = err
+        c.state.lastFail = now
 
-		if c.state.firstFailInCycle.IsZero() {
-			c.state.firstFailInCycle = now
-		}
+        if c.state.firstFailInCycle.IsZero() {
+            c.state.firstFailInCycle = now
+        }
 
-		// Determine status based on grace period and contiguous fails
-		newStatus = StatusDown
-		if c.errorGracePeriod > 0 && now.Sub(c.state.firstFailInCycle) <= c.errorGracePeriod {
-			newStatus = StatusUp // Still within grace period
-		} else if c.maxContiguousFails > 0 && c.state.contiguousFails < c.maxContiguousFails {
-			newStatus = StatusUp // Still within fail threshold
-		}
+        // Determine status based on grace period and contiguous fails
+        newStatus = StatusDown
+        if c.errorGracePeriod > 0 && now.Sub(c.state.firstFailInCycle) <= c.errorGracePeriod {
+            newStatus = StatusUp // Still within grace period
+        } else if c.maxContiguousFails > 0 && c.state.contiguousFails.Load() < c.maxContiguousFails {
+            newStatus = StatusUp // Still within fail threshold
+        }
 
-		// Handle custom status errors
-		statusErr := new(StatusError)
-		if errors.As(err, &statusErr) {
-			if !statusErr.Status.IsValid() {
-				statusErr.Status = StatusUnknown
-			}
-			newStatus = statusErr.Status
-		}
+        // Handle custom status errors
+        statusErr := new(StatusError)
+        if errors.As(err, &statusErr) {
+            if !statusErr.Status.IsValid() {
+                statusErr.Status = StatusUnknown
+            }
+            newStatus = statusErr.Status
+        }
 
-		return err
-	}
+        return err
+    }
 
-	newStatus = StatusUp
-	c.state.lastSuccess = now
-	c.state.contiguousFails = 0
-	c.state.checkErr = nil
-	c.state.firstFailInCycle = time.Time{}
+    newStatus = StatusUp
+    c.state.lastSuccess = now
+    c.state.contiguousFails.Store(0)
+    c.state.checkErr = nil
+    c.state.firstFailInCycle = time.Time{}
 
-	return nil
+    return nil
 }

--- a/health/check_options.go
+++ b/health/check_options.go
@@ -1,15 +1,11 @@
 package health
 
 import (
-	"context"
 	"time"
 )
 
 // CheckOption is a function that modifies the check configuration.
 type CheckOption = func(*Check)
-
-// StatusListenerFunc is a function that is called when the status of the check changes.
-type StatusListenerFunc = func(ctx context.Context, name string, state State)
 
 // WithCheckTimeout sets the timeout for the check.
 func WithCheckTimeout(timeout time.Duration) CheckOption {
@@ -33,7 +29,7 @@ func WithCheckErrorGracePeriod(errorGracePeriod time.Duration) CheckOption {
 }
 
 // WithCheckMaxFailures sets the maximum number of contiguous fails.
-func WithCheckMaxFailures(maxContiguousFails uint) CheckOption {
+func WithCheckMaxFailures(maxContiguousFails uint32) CheckOption {
 	return func(c *Check) {
 		c.maxContiguousFails = maxContiguousFails
 	}

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -3,6 +3,7 @@ package health
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ func TestCheck_Check_Golden(t *testing.T) {
 	c := NewCheck("test", func(ctx context.Context) error {
 		return nil
 	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
 			statusListenerCalled = true
 			require.Equal(t, "test", name)
 			require.Equal(t, StatusUp, state.status)
@@ -31,7 +32,7 @@ func TestCheck_Check_Golden(t *testing.T) {
 		lastCheckTime:   now,
 		lastSuccess:     now,
 		lastFail:        time.Time{},
-		contiguousFails: 0,
+		contiguousFails: atomic.Uint32{},
 		checkErr:        nil,
 		status:          StatusUp,
 	}
@@ -47,7 +48,7 @@ func TestCheck_Check_Golden_FailCheck(t *testing.T) {
 	c := NewCheck("test", func(ctx context.Context) error {
 		return errors.New("test error")
 	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
 			statusListenerCalled = true
 			require.Equal(t, "test", name)
 			require.Equal(t, StatusDown, state.status)
@@ -61,11 +62,12 @@ func TestCheck_Check_Golden_FailCheck(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      time.Time{},
 		lastFail:         now,
-		contiguousFails:  1,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         errors.New("test error"),
 		status:           StatusDown,
 		firstFailInCycle: now,
 	}
+	expectedState.contiguousFails.Store(1)
 	require.Equal(t, expectedState, c.state)
 	require.True(t, statusListenerCalled)
 }
@@ -83,7 +85,7 @@ func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
 		}
 		return nil
 	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
 			statusListenerCalled++
 			if statusListenerCalled%2 == 0 {
 				require.Equal(t, "test", name)
@@ -102,11 +104,12 @@ func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      now,
 		lastFail:         time.Time{},
-		contiguousFails:  0,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         nil,
 		status:           StatusUp,
 		firstFailInCycle: time.Time{},
 	}
+	expectedState.contiguousFails.Store(0)
 	require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
 
 	err = c.Check(context.Background())
@@ -116,11 +119,12 @@ func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      now,
 		lastFail:         now,
-		contiguousFails:  1,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         errors.New("test error"),
 		status:           StatusDown,
 		firstFailInCycle: now,
 	}
+	expectedState.contiguousFails.Store(1)
 	require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
 
 	err = c.Check(context.Background())
@@ -130,11 +134,12 @@ func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      now,
 		lastFail:         now,
-		contiguousFails:  0,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         nil,
 		status:           StatusUp,
 		firstFailInCycle: time.Time{},
 	}
+	expectedState.contiguousFails.Store(0)
 	require.Equal(t, expectedState, c.state)
 	require.Equal(t, 3, statusListenerCalled)
 }
@@ -148,11 +153,11 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 		return errors.New("test error")
 	},
 		WithCheckMaxFailures(3),
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
 			statusListenerCalled++
 			require.Equal(t, "test", name)
 
-			if state.contiguousFails < 3 {
+			if state.contiguousFails.Load() < 3 {
 				require.Equal(t, StatusUp, state.status)
 			} else {
 				require.Equal(t, StatusDown, state.status)
@@ -167,11 +172,12 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      time.Time{},
 		lastFail:         now,
-		contiguousFails:  1,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         errors.New("test error"),
 		status:           StatusUp,
 		firstFailInCycle: now,
 	}
+	expectedState.contiguousFails.Store(1)
 	require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
 	require.Equal(t, 1, statusListenerCalled)
 
@@ -182,11 +188,12 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      time.Time{},
 		lastFail:         now,
-		contiguousFails:  2,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         errors.New("test error"),
 		status:           StatusUp,
 		firstFailInCycle: now,
 	}
+	expectedState.contiguousFails.Store(2)
 	require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
 	require.Equal(t, 1, statusListenerCalled)
 
@@ -197,11 +204,12 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      time.Time{},
 		lastFail:         now,
-		contiguousFails:  3,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         errors.New("test error"),
 		status:           StatusDown,
 		firstFailInCycle: now,
 	}
+	expectedState.contiguousFails.Store(3)
 	require.Equal(t, expectedState, c.state, "Third Check() should update the state correctly")
 	require.Equal(t, 2, statusListenerCalled)
 
@@ -212,11 +220,12 @@ func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      time.Time{},
 		lastFail:         now,
-		contiguousFails:  4,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         errors.New("test error"),
 		status:           StatusDown,
 		firstFailInCycle: now,
 	}
+	expectedState.contiguousFails.Store(4)
 	require.Equal(t, expectedState, c.state, "Fourth Check() should update the state correctly")
 	require.Equal(t, 2, statusListenerCalled)
 }
@@ -236,11 +245,12 @@ func TestCheck_StatusError(t *testing.T) {
 		lastCheckTime:    now,
 		lastSuccess:      time.Time{},
 		lastFail:         now,
-		contiguousFails:  1,
+		contiguousFails:  atomic.Uint32{},
 		checkErr:         NewStatusError(errors.New("test error"), StatusDegraded),
 		status:           StatusDegraded,
 		firstFailInCycle: now,
 	}
+	expectedState.contiguousFails.Store(1)
 	require.Equal(t, expectedState, c.state)
 }
 
@@ -252,7 +262,7 @@ func TestCheck_NoTimeout(t *testing.T) {
 	c := NewCheck("test", func(ctx context.Context) error {
 		return nil
 	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
 			statusListenerCalled = true
 			require.Equal(t, "test", name)
 			require.Equal(t, StatusUp, state.status)
@@ -267,7 +277,7 @@ func TestCheck_NoTimeout(t *testing.T) {
 		lastCheckTime:   now,
 		lastSuccess:     now,
 		lastFail:        time.Time{},
-		contiguousFails: 0,
+		contiguousFails: atomic.Uint32{},
 		checkErr:        nil,
 		status:          StatusUp,
 	}
@@ -283,7 +293,7 @@ func TestCheck_NoParentContext(t *testing.T) {
 	c := NewCheck("test", func(ctx context.Context) error {
 		return nil
 	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
 			statusListenerCalled = true
 			require.Equal(t, "test", name)
 			require.Equal(t, StatusUp, state.status)
@@ -297,10 +307,11 @@ func TestCheck_NoParentContext(t *testing.T) {
 		lastCheckTime:   now,
 		lastSuccess:     now,
 		lastFail:        time.Time{},
-		contiguousFails: 0,
+		contiguousFails: atomic.Uint32{},
 		checkErr:        nil,
 		status:          StatusUp,
 	}
+	expectedState.contiguousFails.Store(0)
 	require.Equal(t, expectedState, c.state)
 	require.True(t, statusListenerCalled)
 }
@@ -315,7 +326,7 @@ func TestCheck_ErrorGracePeriod(t *testing.T) {
 			return errors.New("test error")
 		},
 		WithCheckErrorGracePeriod(5*time.Second),
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
 			statusChanges = append(statusChanges, state.status)
 		}),
 	)
@@ -365,7 +376,7 @@ func TestCheck_ErrorGracePeriod_WithMaxContiguousFails(t *testing.T) {
 		},
 		WithCheckErrorGracePeriod(5*time.Second),
 		WithCheckMaxFailures(3),
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state State) {
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
 			statusChanges = append(statusChanges, state.status)
 		}),
 	)

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -1,410 +1,410 @@
 package health
 
 import (
-    "context"
-    "errors"
-    "sync/atomic"
-    "testing"
-    "time"
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
 
-    "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheck_Check_Golden(t *testing.T) {
-    now := time.Now().UTC()
-    timestamp = func() time.Time { return now }
+	now := time.Now().UTC()
+	timestamp = func() time.Time { return now }
 
-    statusListenerCalled := false
-    c := NewCheck("test", func(ctx context.Context) error {
-        return nil
-    },
-        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-            statusListenerCalled = true
-            require.Equal(t, "test", name)
-            require.Equal(t, StatusUp, state.status)
-        }),
-    )
+	statusListenerCalled := false
+	c := NewCheck("test", func(ctx context.Context) error {
+		return nil
+	},
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+			statusListenerCalled = true
+			require.Equal(t, "test", name)
+			require.Equal(t, StatusUp, state.status)
+		}),
+	)
 
-    err := c.Check(context.Background())
-    require.NoError(t, err)
+	err := c.Check(context.Background())
+	require.NoError(t, err)
 
-    expectedState := &State{
-        lastCheckTime:   now,
-        lastSuccess:     now,
-        lastFail:        time.Time{},
-        contiguousFails: atomic.Uint32{},
-        checkErr:        nil,
-        status:          StatusUp,
-    }
-    compareState(t, expectedState, c.state)
-    require.True(t, statusListenerCalled)
+	expectedState := &State{
+		lastCheckTime:   now,
+		lastSuccess:     now,
+		lastFail:        time.Time{},
+		contiguousFails: atomic.Uint32{},
+		checkErr:        nil,
+		status:          StatusUp,
+	}
+	compareState(t, expectedState, c.state)
+	require.True(t, statusListenerCalled)
 }
 
 func TestCheck_Check_Golden_FailCheck(t *testing.T) {
-    now := time.Now().UTC()
-    timestamp = func() time.Time { return now }
+	now := time.Now().UTC()
+	timestamp = func() time.Time { return now }
 
-    statusListenerCalled := false
-    c := NewCheck("test", func(ctx context.Context) error {
-        return errors.New("test error")
-    },
-        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-            statusListenerCalled = true
-            require.Equal(t, "test", name)
-            require.Equal(t, StatusDown, state.status)
-        }),
-    )
+	statusListenerCalled := false
+	c := NewCheck("test", func(ctx context.Context) error {
+		return errors.New("test error")
+	},
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+			statusListenerCalled = true
+			require.Equal(t, "test", name)
+			require.Equal(t, StatusDown, state.status)
+		}),
+	)
 
-    err := c.Check(context.Background())
-    require.EqualError(t, err, "test error")
+	err := c.Check(context.Background())
+	require.EqualError(t, err, "test error")
 
-    expectedState := &State{
-        lastCheckTime:    now,
-        lastSuccess:      time.Time{},
-        lastFail:         now,
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         errors.New("test error"),
-        status:           StatusDown,
-        firstFailInCycle: now,
-    }
-    expectedState.contiguousFails.Store(1)
-    compareState(t, expectedState, c.state)
-    require.True(t, statusListenerCalled)
+	expectedState := &State{
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         errors.New("test error"),
+		status:           StatusDown,
+		firstFailInCycle: now,
+	}
+	expectedState.contiguousFails.Store(1)
+	compareState(t, expectedState, c.state)
+	require.True(t, statusListenerCalled)
 }
 
 func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
-    now := time.Now().UTC()
-    timestamp = func() time.Time { return now }
+	now := time.Now().UTC()
+	timestamp = func() time.Time { return now }
 
-    statusListenerCalled := 0
-    callNumber := 0
-    c := NewCheck("test", func(ctx context.Context) error {
-        callNumber++
-        if callNumber%2 == 0 {
-            return errors.New("test error")
-        }
-        return nil
-    },
-        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-            statusListenerCalled++
-            if statusListenerCalled%2 == 0 {
-                require.Equal(t, "test", name)
-                require.Equal(t, StatusDown, state.status)
-            } else {
-                require.Equal(t, "test", name)
-                require.Equal(t, StatusUp, state.status)
-            }
-        }),
-    )
+	statusListenerCalled := 0
+	callNumber := 0
+	c := NewCheck("test", func(ctx context.Context) error {
+		callNumber++
+		if callNumber%2 == 0 {
+			return errors.New("test error")
+		}
+		return nil
+	},
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+			statusListenerCalled++
+			if statusListenerCalled%2 == 0 {
+				require.Equal(t, "test", name)
+				require.Equal(t, StatusDown, state.status)
+			} else {
+				require.Equal(t, "test", name)
+				require.Equal(t, StatusUp, state.status)
+			}
+		}),
+	)
 
-    err := c.Check(context.Background())
-    require.NoError(t, err, "First Check() should not return an error")
+	err := c.Check(context.Background())
+	require.NoError(t, err, "First Check() should not return an error")
 
-    expectedState := &State{
-        lastCheckTime:    now,
-        lastSuccess:      now,
-        lastFail:         time.Time{},
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         nil,
-        status:           StatusUp,
-        firstFailInCycle: time.Time{},
-    }
-    expectedState.contiguousFails.Store(0)
-    require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
+	expectedState := &State{
+		lastCheckTime:    now,
+		lastSuccess:      now,
+		lastFail:         time.Time{},
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         nil,
+		status:           StatusUp,
+		firstFailInCycle: time.Time{},
+	}
+	expectedState.contiguousFails.Store(0)
+	require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
 
-    err = c.Check(context.Background())
-    require.EqualError(t, err, "test error", "Second Check() should return the correct error")
+	err = c.Check(context.Background())
+	require.EqualError(t, err, "test error", "Second Check() should return the correct error")
 
-    expectedState = &State{
-        lastCheckTime:    now,
-        lastSuccess:      now,
-        lastFail:         now,
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         errors.New("test error"),
-        status:           StatusDown,
-        firstFailInCycle: now,
-    }
-    expectedState.contiguousFails.Store(1)
-    require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
+	expectedState = &State{
+		lastCheckTime:    now,
+		lastSuccess:      now,
+		lastFail:         now,
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         errors.New("test error"),
+		status:           StatusDown,
+		firstFailInCycle: now,
+	}
+	expectedState.contiguousFails.Store(1)
+	require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
 
-    err = c.Check(context.Background())
-    require.NoError(t, err, "Third Check() should not return an error")
+	err = c.Check(context.Background())
+	require.NoError(t, err, "Third Check() should not return an error")
 
-    expectedState = &State{
-        lastCheckTime:    now,
-        lastSuccess:      now,
-        lastFail:         now,
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         nil,
-        status:           StatusUp,
-        firstFailInCycle: time.Time{},
-    }
-    expectedState.contiguousFails.Store(0)
-    compareState(t, expectedState, c.state)
-    require.Equal(t, 3, statusListenerCalled)
+	expectedState = &State{
+		lastCheckTime:    now,
+		lastSuccess:      now,
+		lastFail:         now,
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         nil,
+		status:           StatusUp,
+		firstFailInCycle: time.Time{},
+	}
+	expectedState.contiguousFails.Store(0)
+	compareState(t, expectedState, c.state)
+	require.Equal(t, 3, statusListenerCalled)
 }
 
 func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
-    now := time.Now().UTC()
-    timestamp = func() time.Time { return now }
+	now := time.Now().UTC()
+	timestamp = func() time.Time { return now }
 
-    statusListenerCalled := 0
-    c := NewCheck("test", func(ctx context.Context) error {
-        return errors.New("test error")
-    },
-        WithCheckMaxFailures(3),
-        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-            statusListenerCalled++
-            require.Equal(t, "test", name)
+	statusListenerCalled := 0
+	c := NewCheck("test", func(ctx context.Context) error {
+		return errors.New("test error")
+	},
+		WithCheckMaxFailures(3),
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+			statusListenerCalled++
+			require.Equal(t, "test", name)
 
-            if state.contiguousFails.Load() < 3 {
-                require.Equal(t, StatusUp, state.status)
-            } else {
-                require.Equal(t, StatusDown, state.status)
-            }
-        }),
-    )
+			if state.contiguousFails.Load() < 3 {
+				require.Equal(t, StatusUp, state.status)
+			} else {
+				require.Equal(t, StatusDown, state.status)
+			}
+		}),
+	)
 
-    err := c.Check(context.Background())
-    require.EqualError(t, err, "test error", "First Check() should return the correct error")
+	err := c.Check(context.Background())
+	require.EqualError(t, err, "test error", "First Check() should return the correct error")
 
-    expectedState := &State{
-        lastCheckTime:    now,
-        lastSuccess:      time.Time{},
-        lastFail:         now,
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         errors.New("test error"),
-        status:           StatusUp,
-        firstFailInCycle: now,
-    }
-    expectedState.contiguousFails.Store(1)
-    require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
-    require.Equal(t, 1, statusListenerCalled)
+	expectedState := &State{
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         errors.New("test error"),
+		status:           StatusUp,
+		firstFailInCycle: now,
+	}
+	expectedState.contiguousFails.Store(1)
+	require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
+	require.Equal(t, 1, statusListenerCalled)
 
-    err = c.Check(context.Background())
-    require.EqualError(t, err, "test error", "Second Check() should return the correct error")
+	err = c.Check(context.Background())
+	require.EqualError(t, err, "test error", "Second Check() should return the correct error")
 
-    expectedState = &State{
-        lastCheckTime:    now,
-        lastSuccess:      time.Time{},
-        lastFail:         now,
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         errors.New("test error"),
-        status:           StatusUp,
-        firstFailInCycle: now,
-    }
-    expectedState.contiguousFails.Store(2)
-    require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
-    require.Equal(t, 1, statusListenerCalled)
+	expectedState = &State{
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         errors.New("test error"),
+		status:           StatusUp,
+		firstFailInCycle: now,
+	}
+	expectedState.contiguousFails.Store(2)
+	require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
+	require.Equal(t, 1, statusListenerCalled)
 
-    err = c.Check(context.Background())
-    require.EqualError(t, err, "test error", "Third Check() should return the correct error")
+	err = c.Check(context.Background())
+	require.EqualError(t, err, "test error", "Third Check() should return the correct error")
 
-    expectedState = &State{
-        lastCheckTime:    now,
-        lastSuccess:      time.Time{},
-        lastFail:         now,
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         errors.New("test error"),
-        status:           StatusDown,
-        firstFailInCycle: now,
-    }
-    expectedState.contiguousFails.Store(3)
-    require.Equal(t, expectedState, c.state, "Third Check() should update the state correctly")
-    require.Equal(t, 2, statusListenerCalled)
+	expectedState = &State{
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         errors.New("test error"),
+		status:           StatusDown,
+		firstFailInCycle: now,
+	}
+	expectedState.contiguousFails.Store(3)
+	require.Equal(t, expectedState, c.state, "Third Check() should update the state correctly")
+	require.Equal(t, 2, statusListenerCalled)
 
-    err = c.Check(context.Background())
-    require.EqualError(t, err, "test error", "Fourth Check() should return the correct error")
+	err = c.Check(context.Background())
+	require.EqualError(t, err, "test error", "Fourth Check() should return the correct error")
 
-    expectedState = &State{
-        lastCheckTime:    now,
-        lastSuccess:      time.Time{},
-        lastFail:         now,
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         errors.New("test error"),
-        status:           StatusDown,
-        firstFailInCycle: now,
-    }
-    expectedState.contiguousFails.Store(4)
-    require.Equal(t, expectedState, c.state, "Fourth Check() should update the state correctly")
-    require.Equal(t, 2, statusListenerCalled)
+	expectedState = &State{
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         errors.New("test error"),
+		status:           StatusDown,
+		firstFailInCycle: now,
+	}
+	expectedState.contiguousFails.Store(4)
+	require.Equal(t, expectedState, c.state, "Fourth Check() should update the state correctly")
+	require.Equal(t, 2, statusListenerCalled)
 }
 
 func TestCheck_StatusError(t *testing.T) {
-    now := time.Now().UTC()
-    timestamp = func() time.Time { return now }
+	now := time.Now().UTC()
+	timestamp = func() time.Time { return now }
 
-    c := NewCheck("test", func(ctx context.Context) error {
-        return NewStatusError(errors.New("test error"), StatusDegraded)
-    })
+	c := NewCheck("test", func(ctx context.Context) error {
+		return NewStatusError(errors.New("test error"), StatusDegraded)
+	})
 
-    err := c.Check(context.Background())
-    require.EqualError(t, err, "test error")
+	err := c.Check(context.Background())
+	require.EqualError(t, err, "test error")
 
-    expectedState := &State{
-        lastCheckTime:    now,
-        lastSuccess:      time.Time{},
-        lastFail:         now,
-        contiguousFails:  atomic.Uint32{},
-        checkErr:         NewStatusError(errors.New("test error"), StatusDegraded),
-        status:           StatusDegraded,
-        firstFailInCycle: now,
-    }
-    expectedState.contiguousFails.Store(1)
-    compareState(t, expectedState, c.state)
+	expectedState := &State{
+		lastCheckTime:    now,
+		lastSuccess:      time.Time{},
+		lastFail:         now,
+		contiguousFails:  atomic.Uint32{},
+		checkErr:         NewStatusError(errors.New("test error"), StatusDegraded),
+		status:           StatusDegraded,
+		firstFailInCycle: now,
+	}
+	expectedState.contiguousFails.Store(1)
+	compareState(t, expectedState, c.state)
 }
 
 func TestCheck_NoTimeout(t *testing.T) {
-    now := time.Now().UTC()
-    timestamp = func() time.Time { return now }
+	now := time.Now().UTC()
+	timestamp = func() time.Time { return now }
 
-    statusListenerCalled := false
-    c := NewCheck("test", func(ctx context.Context) error {
-        return nil
-    },
-        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-            statusListenerCalled = true
-            require.Equal(t, "test", name)
-            require.Equal(t, StatusUp, state.status)
-        }),
-        WithNoCheckTimeout(),
-    )
+	statusListenerCalled := false
+	c := NewCheck("test", func(ctx context.Context) error {
+		return nil
+	},
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+			statusListenerCalled = true
+			require.Equal(t, "test", name)
+			require.Equal(t, StatusUp, state.status)
+		}),
+		WithNoCheckTimeout(),
+	)
 
-    err := c.Check(context.Background())
-    require.NoError(t, err)
+	err := c.Check(context.Background())
+	require.NoError(t, err)
 
-    expectedState := &State{
-        lastCheckTime:   now,
-        lastSuccess:     now,
-        lastFail:        time.Time{},
-        contiguousFails: atomic.Uint32{},
-        checkErr:        nil,
-        status:          StatusUp,
-    }
-    compareState(t, expectedState, c.state)
-    require.True(t, statusListenerCalled)
+	expectedState := &State{
+		lastCheckTime:   now,
+		lastSuccess:     now,
+		lastFail:        time.Time{},
+		contiguousFails: atomic.Uint32{},
+		checkErr:        nil,
+		status:          StatusUp,
+	}
+	compareState(t, expectedState, c.state)
+	require.True(t, statusListenerCalled)
 }
 
 func TestCheck_NoParentContext(t *testing.T) {
-    now := time.Now().UTC()
-    timestamp = func() time.Time { return now }
+	now := time.Now().UTC()
+	timestamp = func() time.Time { return now }
 
-    statusListenerCalled := false
-    c := NewCheck("test", func(ctx context.Context) error {
-        return nil
-    },
-        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-            statusListenerCalled = true
-            require.Equal(t, "test", name)
-            require.Equal(t, StatusUp, state.status)
-        }),
-    )
+	statusListenerCalled := false
+	c := NewCheck("test", func(ctx context.Context) error {
+		return nil
+	},
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+			statusListenerCalled = true
+			require.Equal(t, "test", name)
+			require.Equal(t, StatusUp, state.status)
+		}),
+	)
 
-    err := c.Check(nil) // nolint:staticcheck // This is testing that the function works with a nil context
-    require.NoError(t, err)
+	err := c.Check(nil) // nolint:staticcheck // This is testing that the function works with a nil context
+	require.NoError(t, err)
 
-    expectedState := &State{
-        lastCheckTime:   now,
-        lastSuccess:     now,
-        lastFail:        time.Time{},
-        contiguousFails: atomic.Uint32{},
-        checkErr:        nil,
-        status:          StatusUp,
-    }
-    expectedState.contiguousFails.Store(0)
-    compareState(t, expectedState, c.state)
-    require.True(t, statusListenerCalled)
+	expectedState := &State{
+		lastCheckTime:   now,
+		lastSuccess:     now,
+		lastFail:        time.Time{},
+		contiguousFails: atomic.Uint32{},
+		checkErr:        nil,
+		status:          StatusUp,
+	}
+	expectedState.contiguousFails.Store(0)
+	compareState(t, expectedState, c.state)
+	require.True(t, statusListenerCalled)
 }
 
 func TestCheck_ErrorGracePeriod(t *testing.T) {
-    var currentTime time.Time
-    timestamp = func() time.Time { return currentTime }
+	var currentTime time.Time
+	timestamp = func() time.Time { return currentTime }
 
-    statusChanges := make([]Status, 0)
-    c := NewCheck("test",
-        func(ctx context.Context) error {
-            return errors.New("test error")
-        },
-        WithCheckErrorGracePeriod(5*time.Second),
-        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-            statusChanges = append(statusChanges, state.status)
-        }),
-    )
+	statusChanges := make([]Status, 0)
+	c := NewCheck("test",
+		func(ctx context.Context) error {
+			return errors.New("test error")
+		},
+		WithCheckErrorGracePeriod(5*time.Second),
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+			statusChanges = append(statusChanges, state.status)
+		}),
+	)
 
-    // Start at t=0
-    currentTime = time.Unix(0, 0)
-    err := c.Check(context.Background())
-    require.Error(t, err)
-    require.Equal(t, StatusUp, c.state.status, "should be UP within grace period")
-    require.Equal(t, currentTime, c.state.lastFail)
+	// Start at t=0
+	currentTime = time.Unix(0, 0)
+	err := c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period")
+	require.Equal(t, currentTime, c.state.lastFail)
 
-    // Check at t=3s (within grace period)
-    currentTime = time.Unix(3, 0)
-    err = c.Check(context.Background())
-    require.Error(t, err)
-    require.Equal(t, StatusUp, c.state.status, "should still be UP within grace period")
-    require.Equal(t, currentTime, c.state.lastFail)
+	// Check at t=3s (within grace period)
+	currentTime = time.Unix(3, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should still be UP within grace period")
+	require.Equal(t, currentTime, c.state.lastFail)
 
-    // Check at t=6s (exceeds grace period)
-    currentTime = time.Unix(7, 0)
-    err = c.Check(context.Background())
-    require.Error(t, err)
-    require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
-    require.Equal(t, currentTime, c.state.lastFail)
+	// Check at t=6s (exceeds grace period)
+	currentTime = time.Unix(7, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
+	require.Equal(t, currentTime, c.state.lastFail)
 
-    // Verify status changes
-    require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
+	// Verify status changes
+	require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
 
-    // Verify recovery
-    currentTime = time.Unix(9, 0)
-    c.check = func(ctx context.Context) error { return nil }
-    err = c.Check(context.Background())
-    require.NoError(t, err)
-    require.Equal(t, StatusUp, c.state.status, "should recover to UP")
-    require.Equal(t, time.Unix(7, 0), c.state.lastFail, "lastFail should remain at last failure time")
-    require.Equal(t, []Status{StatusUp, StatusDown, StatusUp}, statusChanges)
+	// Verify recovery
+	currentTime = time.Unix(9, 0)
+	c.check = func(ctx context.Context) error { return nil }
+	err = c.Check(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should recover to UP")
+	require.Equal(t, time.Unix(7, 0), c.state.lastFail, "lastFail should remain at last failure time")
+	require.Equal(t, []Status{StatusUp, StatusDown, StatusUp}, statusChanges)
 }
 
 func TestCheck_ErrorGracePeriod_WithMaxContiguousFails(t *testing.T) {
-    var currentTime time.Time
-    timestamp = func() time.Time { return currentTime }
+	var currentTime time.Time
+	timestamp = func() time.Time { return currentTime }
 
-    statusChanges := make([]Status, 0)
-    c := NewCheck("test",
-        func(ctx context.Context) error {
-            return errors.New("test error")
-        },
-        WithCheckErrorGracePeriod(5*time.Second),
-        WithCheckMaxFailures(3),
-        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-            statusChanges = append(statusChanges, state.status)
-        }),
-    )
+	statusChanges := make([]Status, 0)
+	c := NewCheck("test",
+		func(ctx context.Context) error {
+			return errors.New("test error")
+		},
+		WithCheckErrorGracePeriod(5*time.Second),
+		WithCheckMaxFailures(3),
+		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+			statusChanges = append(statusChanges, state.status)
+		}),
+	)
 
-    // Start at t=0
-    currentTime = time.Unix(0, 0)
-    err := c.Check(context.Background())
-    require.Error(t, err)
-    require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
+	// Start at t=0
+	currentTime = time.Unix(0, 0)
+	err := c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
 
-    // Check at t=3s (failure 2)
-    currentTime = time.Unix(3, 0)
-    err = c.Check(context.Background())
-    require.Error(t, err)
-    require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
+	// Check at t=3s (failure 2)
+	currentTime = time.Unix(3, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
 
-    // Check at t=4s (failure 3)
-    currentTime = time.Unix(4, 0)
-    err = c.Check(context.Background())
-    require.Error(t, err)
-    require.Equal(t, StatusUp, c.state.status, "should be UP within grace period despite max failures")
+	// Check at t=4s (failure 3)
+	currentTime = time.Unix(4, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period despite max failures")
 
-    // Check at t=6s (exceeds grace period)
-    currentTime = time.Unix(6, 0)
-    err = c.Check(context.Background())
-    require.Error(t, err)
-    require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
+	// Check at t=6s (exceeds grace period)
+	currentTime = time.Unix(6, 0)
+	err = c.Check(context.Background())
+	require.Error(t, err)
+	require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
 
-    // Verify status changes
-    require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
+	// Verify status changes
+	require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
 }

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -1,410 +1,410 @@
 package health
 
 import (
-	"context"
-	"errors"
-	"sync/atomic"
-	"testing"
-	"time"
+    "context"
+    "errors"
+    "sync/atomic"
+    "testing"
+    "time"
 
-	"github.com/stretchr/testify/require"
+    "github.com/stretchr/testify/require"
 )
 
 func TestCheck_Check_Golden(t *testing.T) {
-	now := time.Now().UTC()
-	timestamp = func() time.Time { return now }
+    now := time.Now().UTC()
+    timestamp = func() time.Time { return now }
 
-	statusListenerCalled := false
-	c := NewCheck("test", func(ctx context.Context) error {
-		return nil
-	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-			statusListenerCalled = true
-			require.Equal(t, "test", name)
-			require.Equal(t, StatusUp, state.status)
-		}),
-	)
+    statusListenerCalled := false
+    c := NewCheck("test", func(ctx context.Context) error {
+        return nil
+    },
+        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+            statusListenerCalled = true
+            require.Equal(t, "test", name)
+            require.Equal(t, StatusUp, state.status)
+        }),
+    )
 
-	err := c.Check(context.Background())
-	require.NoError(t, err)
+    err := c.Check(context.Background())
+    require.NoError(t, err)
 
-	expectedState := &State{
-		lastCheckTime:   now,
-		lastSuccess:     now,
-		lastFail:        time.Time{},
-		contiguousFails: atomic.Uint32{},
-		checkErr:        nil,
-		status:          StatusUp,
-	}
-	require.Equal(t, expectedState, c.state)
-	require.True(t, statusListenerCalled)
+    expectedState := &State{
+        lastCheckTime:   now,
+        lastSuccess:     now,
+        lastFail:        time.Time{},
+        contiguousFails: atomic.Uint32{},
+        checkErr:        nil,
+        status:          StatusUp,
+    }
+    compareState(t, expectedState, c.state)
+    require.True(t, statusListenerCalled)
 }
 
 func TestCheck_Check_Golden_FailCheck(t *testing.T) {
-	now := time.Now().UTC()
-	timestamp = func() time.Time { return now }
+    now := time.Now().UTC()
+    timestamp = func() time.Time { return now }
 
-	statusListenerCalled := false
-	c := NewCheck("test", func(ctx context.Context) error {
-		return errors.New("test error")
-	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-			statusListenerCalled = true
-			require.Equal(t, "test", name)
-			require.Equal(t, StatusDown, state.status)
-		}),
-	)
+    statusListenerCalled := false
+    c := NewCheck("test", func(ctx context.Context) error {
+        return errors.New("test error")
+    },
+        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+            statusListenerCalled = true
+            require.Equal(t, "test", name)
+            require.Equal(t, StatusDown, state.status)
+        }),
+    )
 
-	err := c.Check(context.Background())
-	require.EqualError(t, err, "test error")
+    err := c.Check(context.Background())
+    require.EqualError(t, err, "test error")
 
-	expectedState := &State{
-		lastCheckTime:    now,
-		lastSuccess:      time.Time{},
-		lastFail:         now,
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         errors.New("test error"),
-		status:           StatusDown,
-		firstFailInCycle: now,
-	}
-	expectedState.contiguousFails.Store(1)
-	require.Equal(t, expectedState, c.state)
-	require.True(t, statusListenerCalled)
+    expectedState := &State{
+        lastCheckTime:    now,
+        lastSuccess:      time.Time{},
+        lastFail:         now,
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         errors.New("test error"),
+        status:           StatusDown,
+        firstFailInCycle: now,
+    }
+    expectedState.contiguousFails.Store(1)
+    compareState(t, expectedState, c.state)
+    require.True(t, statusListenerCalled)
 }
 
 func TestCheck_Check_Golden_SuccessToFailToSuccess(t *testing.T) {
-	now := time.Now().UTC()
-	timestamp = func() time.Time { return now }
+    now := time.Now().UTC()
+    timestamp = func() time.Time { return now }
 
-	statusListenerCalled := 0
-	callNumber := 0
-	c := NewCheck("test", func(ctx context.Context) error {
-		callNumber++
-		if callNumber%2 == 0 {
-			return errors.New("test error")
-		}
-		return nil
-	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-			statusListenerCalled++
-			if statusListenerCalled%2 == 0 {
-				require.Equal(t, "test", name)
-				require.Equal(t, StatusDown, state.status)
-			} else {
-				require.Equal(t, "test", name)
-				require.Equal(t, StatusUp, state.status)
-			}
-		}),
-	)
+    statusListenerCalled := 0
+    callNumber := 0
+    c := NewCheck("test", func(ctx context.Context) error {
+        callNumber++
+        if callNumber%2 == 0 {
+            return errors.New("test error")
+        }
+        return nil
+    },
+        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+            statusListenerCalled++
+            if statusListenerCalled%2 == 0 {
+                require.Equal(t, "test", name)
+                require.Equal(t, StatusDown, state.status)
+            } else {
+                require.Equal(t, "test", name)
+                require.Equal(t, StatusUp, state.status)
+            }
+        }),
+    )
 
-	err := c.Check(context.Background())
-	require.NoError(t, err, "First Check() should not return an error")
+    err := c.Check(context.Background())
+    require.NoError(t, err, "First Check() should not return an error")
 
-	expectedState := &State{
-		lastCheckTime:    now,
-		lastSuccess:      now,
-		lastFail:         time.Time{},
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         nil,
-		status:           StatusUp,
-		firstFailInCycle: time.Time{},
-	}
-	expectedState.contiguousFails.Store(0)
-	require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
+    expectedState := &State{
+        lastCheckTime:    now,
+        lastSuccess:      now,
+        lastFail:         time.Time{},
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         nil,
+        status:           StatusUp,
+        firstFailInCycle: time.Time{},
+    }
+    expectedState.contiguousFails.Store(0)
+    require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
 
-	err = c.Check(context.Background())
-	require.EqualError(t, err, "test error", "Second Check() should return the correct error")
+    err = c.Check(context.Background())
+    require.EqualError(t, err, "test error", "Second Check() should return the correct error")
 
-	expectedState = &State{
-		lastCheckTime:    now,
-		lastSuccess:      now,
-		lastFail:         now,
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         errors.New("test error"),
-		status:           StatusDown,
-		firstFailInCycle: now,
-	}
-	expectedState.contiguousFails.Store(1)
-	require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
+    expectedState = &State{
+        lastCheckTime:    now,
+        lastSuccess:      now,
+        lastFail:         now,
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         errors.New("test error"),
+        status:           StatusDown,
+        firstFailInCycle: now,
+    }
+    expectedState.contiguousFails.Store(1)
+    require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
 
-	err = c.Check(context.Background())
-	require.NoError(t, err, "Third Check() should not return an error")
+    err = c.Check(context.Background())
+    require.NoError(t, err, "Third Check() should not return an error")
 
-	expectedState = &State{
-		lastCheckTime:    now,
-		lastSuccess:      now,
-		lastFail:         now,
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         nil,
-		status:           StatusUp,
-		firstFailInCycle: time.Time{},
-	}
-	expectedState.contiguousFails.Store(0)
-	require.Equal(t, expectedState, c.state)
-	require.Equal(t, 3, statusListenerCalled)
+    expectedState = &State{
+        lastCheckTime:    now,
+        lastSuccess:      now,
+        lastFail:         now,
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         nil,
+        status:           StatusUp,
+        firstFailInCycle: time.Time{},
+    }
+    expectedState.contiguousFails.Store(0)
+    compareState(t, expectedState, c.state)
+    require.Equal(t, 3, statusListenerCalled)
 }
 
 func TestCheck_Check_Golden_MaxContiguousFails(t *testing.T) {
-	now := time.Now().UTC()
-	timestamp = func() time.Time { return now }
+    now := time.Now().UTC()
+    timestamp = func() time.Time { return now }
 
-	statusListenerCalled := 0
-	c := NewCheck("test", func(ctx context.Context) error {
-		return errors.New("test error")
-	},
-		WithCheckMaxFailures(3),
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-			statusListenerCalled++
-			require.Equal(t, "test", name)
+    statusListenerCalled := 0
+    c := NewCheck("test", func(ctx context.Context) error {
+        return errors.New("test error")
+    },
+        WithCheckMaxFailures(3),
+        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+            statusListenerCalled++
+            require.Equal(t, "test", name)
 
-			if state.contiguousFails.Load() < 3 {
-				require.Equal(t, StatusUp, state.status)
-			} else {
-				require.Equal(t, StatusDown, state.status)
-			}
-		}),
-	)
+            if state.contiguousFails.Load() < 3 {
+                require.Equal(t, StatusUp, state.status)
+            } else {
+                require.Equal(t, StatusDown, state.status)
+            }
+        }),
+    )
 
-	err := c.Check(context.Background())
-	require.EqualError(t, err, "test error", "First Check() should return the correct error")
+    err := c.Check(context.Background())
+    require.EqualError(t, err, "test error", "First Check() should return the correct error")
 
-	expectedState := &State{
-		lastCheckTime:    now,
-		lastSuccess:      time.Time{},
-		lastFail:         now,
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         errors.New("test error"),
-		status:           StatusUp,
-		firstFailInCycle: now,
-	}
-	expectedState.contiguousFails.Store(1)
-	require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
-	require.Equal(t, 1, statusListenerCalled)
+    expectedState := &State{
+        lastCheckTime:    now,
+        lastSuccess:      time.Time{},
+        lastFail:         now,
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         errors.New("test error"),
+        status:           StatusUp,
+        firstFailInCycle: now,
+    }
+    expectedState.contiguousFails.Store(1)
+    require.Equal(t, expectedState, c.state, "First Check() should update the state correctly")
+    require.Equal(t, 1, statusListenerCalled)
 
-	err = c.Check(context.Background())
-	require.EqualError(t, err, "test error", "Second Check() should return the correct error")
+    err = c.Check(context.Background())
+    require.EqualError(t, err, "test error", "Second Check() should return the correct error")
 
-	expectedState = &State{
-		lastCheckTime:    now,
-		lastSuccess:      time.Time{},
-		lastFail:         now,
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         errors.New("test error"),
-		status:           StatusUp,
-		firstFailInCycle: now,
-	}
-	expectedState.contiguousFails.Store(2)
-	require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
-	require.Equal(t, 1, statusListenerCalled)
+    expectedState = &State{
+        lastCheckTime:    now,
+        lastSuccess:      time.Time{},
+        lastFail:         now,
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         errors.New("test error"),
+        status:           StatusUp,
+        firstFailInCycle: now,
+    }
+    expectedState.contiguousFails.Store(2)
+    require.Equal(t, expectedState, c.state, "Second Check() should update the state correctly")
+    require.Equal(t, 1, statusListenerCalled)
 
-	err = c.Check(context.Background())
-	require.EqualError(t, err, "test error", "Third Check() should return the correct error")
+    err = c.Check(context.Background())
+    require.EqualError(t, err, "test error", "Third Check() should return the correct error")
 
-	expectedState = &State{
-		lastCheckTime:    now,
-		lastSuccess:      time.Time{},
-		lastFail:         now,
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         errors.New("test error"),
-		status:           StatusDown,
-		firstFailInCycle: now,
-	}
-	expectedState.contiguousFails.Store(3)
-	require.Equal(t, expectedState, c.state, "Third Check() should update the state correctly")
-	require.Equal(t, 2, statusListenerCalled)
+    expectedState = &State{
+        lastCheckTime:    now,
+        lastSuccess:      time.Time{},
+        lastFail:         now,
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         errors.New("test error"),
+        status:           StatusDown,
+        firstFailInCycle: now,
+    }
+    expectedState.contiguousFails.Store(3)
+    require.Equal(t, expectedState, c.state, "Third Check() should update the state correctly")
+    require.Equal(t, 2, statusListenerCalled)
 
-	err = c.Check(context.Background())
-	require.EqualError(t, err, "test error", "Fourth Check() should return the correct error")
+    err = c.Check(context.Background())
+    require.EqualError(t, err, "test error", "Fourth Check() should return the correct error")
 
-	expectedState = &State{
-		lastCheckTime:    now,
-		lastSuccess:      time.Time{},
-		lastFail:         now,
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         errors.New("test error"),
-		status:           StatusDown,
-		firstFailInCycle: now,
-	}
-	expectedState.contiguousFails.Store(4)
-	require.Equal(t, expectedState, c.state, "Fourth Check() should update the state correctly")
-	require.Equal(t, 2, statusListenerCalled)
+    expectedState = &State{
+        lastCheckTime:    now,
+        lastSuccess:      time.Time{},
+        lastFail:         now,
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         errors.New("test error"),
+        status:           StatusDown,
+        firstFailInCycle: now,
+    }
+    expectedState.contiguousFails.Store(4)
+    require.Equal(t, expectedState, c.state, "Fourth Check() should update the state correctly")
+    require.Equal(t, 2, statusListenerCalled)
 }
 
 func TestCheck_StatusError(t *testing.T) {
-	now := time.Now().UTC()
-	timestamp = func() time.Time { return now }
+    now := time.Now().UTC()
+    timestamp = func() time.Time { return now }
 
-	c := NewCheck("test", func(ctx context.Context) error {
-		return NewStatusError(errors.New("test error"), StatusDegraded)
-	})
+    c := NewCheck("test", func(ctx context.Context) error {
+        return NewStatusError(errors.New("test error"), StatusDegraded)
+    })
 
-	err := c.Check(context.Background())
-	require.EqualError(t, err, "test error")
+    err := c.Check(context.Background())
+    require.EqualError(t, err, "test error")
 
-	expectedState := &State{
-		lastCheckTime:    now,
-		lastSuccess:      time.Time{},
-		lastFail:         now,
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         NewStatusError(errors.New("test error"), StatusDegraded),
-		status:           StatusDegraded,
-		firstFailInCycle: now,
-	}
-	expectedState.contiguousFails.Store(1)
-	require.Equal(t, expectedState, c.state)
+    expectedState := &State{
+        lastCheckTime:    now,
+        lastSuccess:      time.Time{},
+        lastFail:         now,
+        contiguousFails:  atomic.Uint32{},
+        checkErr:         NewStatusError(errors.New("test error"), StatusDegraded),
+        status:           StatusDegraded,
+        firstFailInCycle: now,
+    }
+    expectedState.contiguousFails.Store(1)
+    compareState(t, expectedState, c.state)
 }
 
 func TestCheck_NoTimeout(t *testing.T) {
-	now := time.Now().UTC()
-	timestamp = func() time.Time { return now }
+    now := time.Now().UTC()
+    timestamp = func() time.Time { return now }
 
-	statusListenerCalled := false
-	c := NewCheck("test", func(ctx context.Context) error {
-		return nil
-	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-			statusListenerCalled = true
-			require.Equal(t, "test", name)
-			require.Equal(t, StatusUp, state.status)
-		}),
-		WithNoCheckTimeout(),
-	)
+    statusListenerCalled := false
+    c := NewCheck("test", func(ctx context.Context) error {
+        return nil
+    },
+        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+            statusListenerCalled = true
+            require.Equal(t, "test", name)
+            require.Equal(t, StatusUp, state.status)
+        }),
+        WithNoCheckTimeout(),
+    )
 
-	err := c.Check(context.Background())
-	require.NoError(t, err)
+    err := c.Check(context.Background())
+    require.NoError(t, err)
 
-	expectedState := &State{
-		lastCheckTime:   now,
-		lastSuccess:     now,
-		lastFail:        time.Time{},
-		contiguousFails: atomic.Uint32{},
-		checkErr:        nil,
-		status:          StatusUp,
-	}
-	require.Equal(t, expectedState, c.state)
-	require.True(t, statusListenerCalled)
+    expectedState := &State{
+        lastCheckTime:   now,
+        lastSuccess:     now,
+        lastFail:        time.Time{},
+        contiguousFails: atomic.Uint32{},
+        checkErr:        nil,
+        status:          StatusUp,
+    }
+    compareState(t, expectedState, c.state)
+    require.True(t, statusListenerCalled)
 }
 
 func TestCheck_NoParentContext(t *testing.T) {
-	now := time.Now().UTC()
-	timestamp = func() time.Time { return now }
+    now := time.Now().UTC()
+    timestamp = func() time.Time { return now }
 
-	statusListenerCalled := false
-	c := NewCheck("test", func(ctx context.Context) error {
-		return nil
-	},
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-			statusListenerCalled = true
-			require.Equal(t, "test", name)
-			require.Equal(t, StatusUp, state.status)
-		}),
-	)
+    statusListenerCalled := false
+    c := NewCheck("test", func(ctx context.Context) error {
+        return nil
+    },
+        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+            statusListenerCalled = true
+            require.Equal(t, "test", name)
+            require.Equal(t, StatusUp, state.status)
+        }),
+    )
 
-	err := c.Check(nil) // nolint:staticcheck // This is testing that the function works with a nil context
-	require.NoError(t, err)
+    err := c.Check(nil) // nolint:staticcheck // This is testing that the function works with a nil context
+    require.NoError(t, err)
 
-	expectedState := &State{
-		lastCheckTime:   now,
-		lastSuccess:     now,
-		lastFail:        time.Time{},
-		contiguousFails: atomic.Uint32{},
-		checkErr:        nil,
-		status:          StatusUp,
-	}
-	expectedState.contiguousFails.Store(0)
-	require.Equal(t, expectedState, c.state)
-	require.True(t, statusListenerCalled)
+    expectedState := &State{
+        lastCheckTime:   now,
+        lastSuccess:     now,
+        lastFail:        time.Time{},
+        contiguousFails: atomic.Uint32{},
+        checkErr:        nil,
+        status:          StatusUp,
+    }
+    expectedState.contiguousFails.Store(0)
+    compareState(t, expectedState, c.state)
+    require.True(t, statusListenerCalled)
 }
 
 func TestCheck_ErrorGracePeriod(t *testing.T) {
-	var currentTime time.Time
-	timestamp = func() time.Time { return currentTime }
+    var currentTime time.Time
+    timestamp = func() time.Time { return currentTime }
 
-	statusChanges := make([]Status, 0)
-	c := NewCheck("test",
-		func(ctx context.Context) error {
-			return errors.New("test error")
-		},
-		WithCheckErrorGracePeriod(5*time.Second),
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-			statusChanges = append(statusChanges, state.status)
-		}),
-	)
+    statusChanges := make([]Status, 0)
+    c := NewCheck("test",
+        func(ctx context.Context) error {
+            return errors.New("test error")
+        },
+        WithCheckErrorGracePeriod(5*time.Second),
+        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+            statusChanges = append(statusChanges, state.status)
+        }),
+    )
 
-	// Start at t=0
-	currentTime = time.Unix(0, 0)
-	err := c.Check(context.Background())
-	require.Error(t, err)
-	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period")
-	require.Equal(t, currentTime, c.state.lastFail)
+    // Start at t=0
+    currentTime = time.Unix(0, 0)
+    err := c.Check(context.Background())
+    require.Error(t, err)
+    require.Equal(t, StatusUp, c.state.status, "should be UP within grace period")
+    require.Equal(t, currentTime, c.state.lastFail)
 
-	// Check at t=3s (within grace period)
-	currentTime = time.Unix(3, 0)
-	err = c.Check(context.Background())
-	require.Error(t, err)
-	require.Equal(t, StatusUp, c.state.status, "should still be UP within grace period")
-	require.Equal(t, currentTime, c.state.lastFail)
+    // Check at t=3s (within grace period)
+    currentTime = time.Unix(3, 0)
+    err = c.Check(context.Background())
+    require.Error(t, err)
+    require.Equal(t, StatusUp, c.state.status, "should still be UP within grace period")
+    require.Equal(t, currentTime, c.state.lastFail)
 
-	// Check at t=6s (exceeds grace period)
-	currentTime = time.Unix(7, 0)
-	err = c.Check(context.Background())
-	require.Error(t, err)
-	require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
-	require.Equal(t, currentTime, c.state.lastFail)
+    // Check at t=6s (exceeds grace period)
+    currentTime = time.Unix(7, 0)
+    err = c.Check(context.Background())
+    require.Error(t, err)
+    require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
+    require.Equal(t, currentTime, c.state.lastFail)
 
-	// Verify status changes
-	require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
+    // Verify status changes
+    require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
 
-	// Verify recovery
-	currentTime = time.Unix(9, 0)
-	c.check = func(ctx context.Context) error { return nil }
-	err = c.Check(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, StatusUp, c.state.status, "should recover to UP")
-	require.Equal(t, time.Unix(7, 0), c.state.lastFail, "lastFail should remain at last failure time")
-	require.Equal(t, []Status{StatusUp, StatusDown, StatusUp}, statusChanges)
+    // Verify recovery
+    currentTime = time.Unix(9, 0)
+    c.check = func(ctx context.Context) error { return nil }
+    err = c.Check(context.Background())
+    require.NoError(t, err)
+    require.Equal(t, StatusUp, c.state.status, "should recover to UP")
+    require.Equal(t, time.Unix(7, 0), c.state.lastFail, "lastFail should remain at last failure time")
+    require.Equal(t, []Status{StatusUp, StatusDown, StatusUp}, statusChanges)
 }
 
 func TestCheck_ErrorGracePeriod_WithMaxContiguousFails(t *testing.T) {
-	var currentTime time.Time
-	timestamp = func() time.Time { return currentTime }
+    var currentTime time.Time
+    timestamp = func() time.Time { return currentTime }
 
-	statusChanges := make([]Status, 0)
-	c := NewCheck("test",
-		func(ctx context.Context) error {
-			return errors.New("test error")
-		},
-		WithCheckErrorGracePeriod(5*time.Second),
-		WithCheckMaxFailures(3),
-		WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
-			statusChanges = append(statusChanges, state.status)
-		}),
-	)
+    statusChanges := make([]Status, 0)
+    c := NewCheck("test",
+        func(ctx context.Context) error {
+            return errors.New("test error")
+        },
+        WithCheckErrorGracePeriod(5*time.Second),
+        WithCheckMaxFailures(3),
+        WithCheckOnStatusChange(func(ctx context.Context, name string, state *State) {
+            statusChanges = append(statusChanges, state.status)
+        }),
+    )
 
-	// Start at t=0
-	currentTime = time.Unix(0, 0)
-	err := c.Check(context.Background())
-	require.Error(t, err)
-	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
+    // Start at t=0
+    currentTime = time.Unix(0, 0)
+    err := c.Check(context.Background())
+    require.Error(t, err)
+    require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
 
-	// Check at t=3s (failure 2)
-	currentTime = time.Unix(3, 0)
-	err = c.Check(context.Background())
-	require.Error(t, err)
-	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
+    // Check at t=3s (failure 2)
+    currentTime = time.Unix(3, 0)
+    err = c.Check(context.Background())
+    require.Error(t, err)
+    require.Equal(t, StatusUp, c.state.status, "should be UP within grace period and max failures")
 
-	// Check at t=4s (failure 3)
-	currentTime = time.Unix(4, 0)
-	err = c.Check(context.Background())
-	require.Error(t, err)
-	require.Equal(t, StatusUp, c.state.status, "should be UP within grace period despite max failures")
+    // Check at t=4s (failure 3)
+    currentTime = time.Unix(4, 0)
+    err = c.Check(context.Background())
+    require.Error(t, err)
+    require.Equal(t, StatusUp, c.state.status, "should be UP within grace period despite max failures")
 
-	// Check at t=6s (exceeds grace period)
-	currentTime = time.Unix(6, 0)
-	err = c.Check(context.Background())
-	require.Error(t, err)
-	require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
+    // Check at t=6s (exceeds grace period)
+    currentTime = time.Unix(6, 0)
+    err = c.Check(context.Background())
+    require.Error(t, err)
+    require.Equal(t, StatusDown, c.state.status, "should be DOWN after grace period")
 
-	// Verify status changes
-	require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
+    // Verify status changes
+    require.Equal(t, []Status{StatusUp, StatusDown}, statusChanges)
 }

--- a/health/state_test.go
+++ b/health/state_test.go
@@ -1,0 +1,19 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func compareState(t *testing.T, expected, actual *State) {
+	t.Helper()
+
+	require.True(t, expected.lastCheckTime.Equal(actual.lastCheckTime), "lastCheckTime mismatch: expected %v, got %v", expected.lastCheckTime, actual.lastCheckTime)
+	require.True(t, expected.lastSuccess.Equal(actual.lastSuccess), "lastSuccess mismatch: expected %v, got %v", expected.lastSuccess, actual.lastSuccess)
+	require.True(t, expected.lastFail.Equal(actual.lastFail), "lastFail mismatch: expected %v, got %v", expected.lastFail, actual.lastFail)
+	require.Equal(t, expected.contiguousFails.Load(), actual.contiguousFails.Load(), "contiguousFails mismatch")
+	require.Equal(t, expected.checkErr, actual.checkErr, "checkErr mismatch")
+	require.Equal(t, expected.status, actual.status, "status mismatch")
+	require.True(t, expected.firstFailInCycle.Equal(actual.firstFailInCycle), "firstFailInCycle mismatch: expected %v, got %v", expected.firstFailInCycle, actual.firstFailInCycle)
+}

--- a/health/status.go
+++ b/health/status.go
@@ -86,7 +86,7 @@ func (s Status) MarshalJSON() ([]byte, error) {
 //		health.WithCheckOnStatusChange(health.StandardStatusListener(logging.LoggerWithComponent(l, "health-check"))),
 //	)
 func StandardStatusListener(l *slog.Logger) StatusListenerFunc {
-	return func(ctx context.Context, name string, state State) {
+	return func(ctx context.Context, name string, state *State) {
 		l.Info("health check status changed",
 			slog.String(logging.KeyName, name),
 			slog.String(logging.KeyState, state.Status().String()),


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces several improvements and refactors to the `health` package, focusing on enhancing thread safety, simplifying state management, and improving type consistency. The key changes include replacing the `contiguousFails` field with an `atomic.Uint32` for thread-safe operations, introducing a `NewState` constructor for initializing `State` objects, and updating related tests and methods for compatibility.

### Thread safety improvements:
* Replaced the `contiguousFails` field in the `State` struct with `atomic.Uint32` to ensure thread-safe operations. Updated related methods to use atomic operations (`health/state.go`, [[1]](diffhunk://#diff-f61fb254e0f31d74ad9b263d11b4ecfbe06610ad869e1baeb8b379d8c72e7132L20-R23) [[2]](diffhunk://#diff-f61fb254e0f31d74ad9b263d11b4ecfbe06610ad869e1baeb8b379d8c72e7132L39-R55).
* Updated the `Check` method to use `atomic.Uint32` operations (`Add`, `Load`, `Store`) for modifying and reading `contiguousFails` (`health/check.go`, [[1]](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dL85-R95) [[2]](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dL104-R107) [[3]](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dL122-R125).

### State management simplifications:
* Added a `NewState` constructor to initialize `State` objects with default values, replacing inline initialization (`health/state.go`, [health/state.goR32-R43](diffhunk://#diff-f61fb254e0f31d74ad9b263d11b4ecfbe06610ad869e1baeb8b379d8c72e7132R32-R43)).
* Updated the `NewCheck` function to use `NewState` for initializing the `state` field (`health/check.go`, [health/check.goL46-R49](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dL46-R49)).

### Type consistency:
* Changed the type of `maxContiguousFails` from `uint` to `uint32` for consistency with `contiguousFails` (`health/check.go`, [health/check.goL27-R33](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dL27-R33)).
* Updated the `WithCheckMaxFailures` option to accept `uint32` instead of `uint` (`health/check_options.go`, [health/check_options.goL36-R32](diffhunk://#diff-da6e34d615c9bcd2a3a764e7e0664a0b5e7f8fcddc82f2e6f3fa7fc1520455dfL36-R32)).

### Listener function refactor:
* Updated the `StatusListenerFunc` signature to accept a pointer to `State` instead of a value, reducing unnecessary copying of the `State` object (`health/check.go`, [[1]](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dR12-R14) [[2]](diffhunk://#diff-ada481bd2b6582ee48931f6d536520d9ea07a436b438c54ae7cd8bb04de4004dL27-R33).

### Test updates:
* Refactored tests to accommodate changes in `State` and `StatusListenerFunc`. Updated test cases to use `atomic.Uint32` for `contiguousFails` and ensure thread-safe operations (`health/check_test.go`, [[1]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1L34-R35) [[2]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1L64-R70) [[3]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1L119-R127) [[4]](diffhunk://#diff-3170350b5358ef098939d29c2ed8f811641424608163c69a44aea27b9e53f8c1L200-R212).