### PR TITLE
chore(health): removing redunant init in constructor

### DIFF
--- a/health/state.go
+++ b/health/state.go
@@ -31,13 +31,7 @@ type State struct {
 
 func NewState() *State {
 	return &State{
-		lastCheckTime:    time.Time{},
-		lastSuccess:      time.Time{},
-		lastFail:         time.Time{},
-		firstFailInCycle: time.Time{},
-		contiguousFails:  atomic.Uint32{},
-		checkErr:         nil,
-		status:           StatusUnknown,
+		status: StatusUnknown,
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request makes a minor change to the initialization logic of the `State` struct in `health/state.go`. It removes the explicit initialization of several fields with their zero values, simplifying the code.

Code simplification:

* [`health/state.go`](diffhunk://#diff-f61fb254e0f31d74ad9b263d11b4ecfbe06610ad869e1baeb8b379d8c72e7132L34-L39): Removed redundant explicit initialization of `lastCheckTime`, `lastSuccess`, `lastFail`, `firstFailInCycle`, `contiguousFails`, and `checkErr` fields in the `NewState` function, as they are already initialized to their zero values by default.