### PR TITLE
chore(app): using more accurate naming of the keys

### DIFF
--- a/app.go
+++ b/app.go
@@ -187,7 +187,7 @@ func (a *App) Start(opts ...StartOption) error {
 		a.l.Info("starting application",
 			slog.String(logging.KeyGitCommit, version.GitCommit()),
 			slog.String(logging.KeyRuntime, fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)),
-			slog.String(logging.KeyBuildDate, version.CommitTimestamp().String()),
+			slog.String(logging.KeyCommitTimestamp, version.CommitTimestamp().String()),
 		)
 
 		for _, opt := range opts {

--- a/logging/keys.go
+++ b/logging/keys.go
@@ -10,8 +10,8 @@ const (
 	// KeyRuntime represents the key for the runtime.
 	KeyRuntime = `runtime`
 
-	// KeyBuildDate represents the key for the build date.
-	KeyBuildDate = `build_date`
+	// KeyCommitTimestamp represents the key for the build date.
+	KeyCommitTimestamp = `commit_timestamp`
 
 	// KeyError represents the key for the error.
 	KeyError = `err`

--- a/logging/keys.go
+++ b/logging/keys.go
@@ -10,7 +10,7 @@ const (
 	// KeyRuntime represents the key for the runtime.
 	KeyRuntime = `runtime`
 
-	// KeyCommitTimestamp represents the key for the build date.
+	// KeyCommitTimestamp represents the key for the commit timestamp.
 	KeyCommitTimestamp = `commit_timestamp`
 
 	// KeyError represents the key for the error.

--- a/version/info.go
+++ b/version/info.go
@@ -8,14 +8,17 @@ import (
 )
 
 const (
-	// revisionKey is the key for the revision.
-	revisionKey = "vcs.revision"
+	// vcs is the key for the version control system.
+	vcsKey = "vcs"
 
-	// buildDateKey is the key for the build date.
-	buildDateKey = "vcs.time" // Timestamp of the commit
+	// revisionKey is the key for the revision.
+	revisionKey = vcsKey + ".revision"
+
+	// commitTimestampKey is the key for the commit timestamp.
+	commitTimestampKey = vcsKey + ".time"
 
 	// modifiedKey is the key for the modified flag.
-	modifiedKey = "vcs.modified" // Set to true (as a string) if the binary was built from a working directory containing uncommitted changes.
+	modifiedKey = vcsKey + ".modified" // Set to true (as a string) if the binary was built from a working directory containing uncommitted changes.
 )
 
 // GitCommit returns the git commit hash of the current build.
@@ -35,7 +38,7 @@ var GitCommit = sync.OnceValue(func() string {
 var CommitTimestamp = sync.OnceValue(func() time.Time {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, setting := range info.Settings {
-			if setting.Key != buildDateKey {
+			if setting.Key != commitTimestampKey {
 				continue
 			}
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request updates terminology and variable names across the codebase to replace references to "build date" with "commit timestamp" for improved clarity and consistency. The changes primarily affect logging keys, constants, and variable names.

### Terminology Update: "Build Date" to "Commit Timestamp"

* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL190-R190): Updated the logging key from `KeyBuildDate` to `KeyCommitTimestamp` in the application startup log.
* [`logging/keys.go`](diffhunk://#diff-11370429fb3a5cf39d3a08b09329a2b4aa4815b3b973287d6267834201ea416dL13-R14): Renamed `KeyBuildDate` to `KeyCommitTimestamp` to reflect the change in terminology.
* `version/info.go`:
  * Introduced `vcsKey` as a base key for version control system-related constants and updated `revisionKey`, `buildDateKey`, and `modifiedKey` to use this base key for consistency.
  * Replaced `buildDateKey` with `commitTimestampKey` in the `CommitTimestamp` function to align with the new terminology.