### PR TITLE
feat(app): setting up and using the config map informers

### DIFF
--- a/app.go
+++ b/app.go
@@ -143,6 +143,14 @@ type (
 		// Provides read-only access to Secret resources.
 		secretLister listersv1.SecretLister
 
+		// configMapInformer is an informer for Kubernetes ConfigMap objects.
+		// Watches for changes to ConfigMap resources in the cluster.
+		configMapInformer kubeCache.SharedIndexInformer
+
+		// configMapLister is a lister for Kubernetes ConfigMap objects.
+		// Provides read-only access to ConfigMap resources.
+		configMapLister listersv1.ConfigMapLister
+
 		// leaderElection is the leader election for the application.
 		// Manages leader election for distributed systems.
 		leaderElection *leaderelection.LeaderElector
@@ -931,6 +939,42 @@ func (a *App) SecretInformer() kubeCache.SharedIndexInformer {
 		panic("secret informer has not been registered")
 	}
 	return a.secretInformer
+}
+
+// ConfigMapLister returns the config map lister for the application.
+//
+// This function ensures that the config map lister is properly initialized before returning it.
+// If the config map lister is not registered, it logs an error and panics.
+//
+// Returns:
+//   - listersv1.ConfigMapLister: The config map lister instance for the application.
+//
+// Panics:
+//   - If the config map lister has not been registered.
+func (a *App) ConfigMapLister() listersv1.ConfigMapLister {
+	if a.configMapLister == nil {
+		a.l.Error("config map lister has not been registered")
+		panic("config map lister has not been registered")
+	}
+	return a.configMapLister
+}
+
+// ConfigMapInformer returns the config map informer for the application.
+//
+// This function ensures that the config map informer is properly initialized before returning it.
+// If the config map informer is not registered, it logs an error and panics.
+//
+// Returns:
+//   - kubeCache.SharedIndexInformer: The config map informer instance for the application.
+//
+// Panics:
+//   - If the config map informer has not been registered.
+func (a *App) ConfigMapInformer() kubeCache.SharedIndexInformer {
+	if a.configMapInformer == nil {
+		a.l.Error("config map informer has not been registered")
+		panic("config map informer has not been registered")
+	}
+	return a.configMapInformer
 }
 
 // waitUntilStarted blocks until the application has completed its startup sequence.

--- a/options.go
+++ b/options.go
@@ -720,3 +720,34 @@ func WithKubernetesSecretInformer(informerOptions ...informers.SharedInformerOpt
 		return nil
 	}
 }
+
+// WithKubernetesConfigMapInformer is a StartOption that sets up a Kubernetes ConfigMap informer.
+//
+// This function initializes a Kubernetes SharedInformerFactory and creates an informer
+// for Kubernetes ConfigMap objects. The informer is used to watch and cache ConfigMap resources
+// in the Kubernetes cluster.
+//
+// Parameters:
+//   - informerOptions: A variadic list of SharedInformerOption values to configure the SharedInformerFactory.
+//
+// Returns:
+//   - StartOption: A function that applies the Kubernetes ConfigMap informer setup to the application.
+//
+// Behavior:
+//   - Initializes the Kubernetes SharedInformerFactory with the provided options.
+//   - Creates an informer and lister for Kubernetes ConfigMap objects.
+//   - Logs the creation of the Kubernetes ConfigMap informer.
+//
+// Errors:
+//   - Returns an error if the Kubernetes SharedInformerFactory cannot be initialized.
+func WithKubernetesConfigMapInformer(informerOptions ...informers.SharedInformerOption) StartOption {
+	return func(a *App) error {
+		initKubernetesInformerFactory(a, informerOptions...)
+
+		a.l.Info("creating kubernetes configmap informer")
+		base := a.kubernetesInformerFactory.Core().V1().ConfigMaps()
+		a.configMapInformer = base.Informer()
+		a.configMapLister = base.Lister()
+		return nil
+	}
+}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces support for managing Kubernetes ConfigMap resources in the application. Key changes include adding new fields to the `App` struct for ConfigMap handling, creating getter methods for the ConfigMap informer and lister, and implementing a new `StartOption` to initialize the ConfigMap informer.

### Enhancements for ConfigMap Support:

* **`app.go`: Added fields to the `App` struct for ConfigMap handling.**  
  Introduced `configMapInformer` and `configMapLister` to manage Kubernetes ConfigMap objects. These fields provide the ability to watch and cache ConfigMap resources in the cluster.

* **`app.go`: Added getter methods for ConfigMap informer and lister.**  
  Implemented `ConfigMapInformer` and `ConfigMapLister` methods to ensure proper initialization of the ConfigMap informer and lister. Both methods log an error and panic if the respective field has not been registered.

* **`options.go`: Added `WithKubernetesConfigMapInformer` StartOption.**  
  Created a new `StartOption` to set up a Kubernetes ConfigMap informer. This function initializes the SharedInformerFactory, creates the ConfigMap informer and lister, and logs the setup process.