### PR TITLE
feat(k8s): upserting secrets

### DIFF
--- a/k8s/resource.go
+++ b/k8s/resource.go
@@ -48,7 +48,7 @@ func UpsertResource(ctx context.Context, kubeClient kubernetes.Interface, resour
 	case *corev1.ConfigMap:
 		return upsert(ctx, kubeClient.CoreV1().ConfigMaps(resource.GetNamespace()), v)
 	case *corev1.Secret:
-		return upsert(ctx, kubeClient.CoreV1().Secrets(v.Namespace), v)
+		return upsert(ctx, kubeClient.CoreV1().Secrets(resource.GetNamespace()), v)
 	default:
 		return fmt.Errorf("unsupported resource type: %T", resource)
 	}

--- a/k8s/resource.go
+++ b/k8s/resource.go
@@ -47,6 +47,8 @@ func UpsertResource(ctx context.Context, kubeClient kubernetes.Interface, resour
 	switch v := resource.(type) {
 	case *corev1.ConfigMap:
 		return upsert(ctx, kubeClient.CoreV1().ConfigMaps(resource.GetNamespace()), v)
+	case *corev1.Secret:
+		return upsert(ctx, kubeClient.CoreV1().Secrets(v.Namespace), v)
 	default:
 		return fmt.Errorf("unsupported resource type: %T", resource)
 	}
@@ -60,6 +62,7 @@ func upsert[U Upserter[T], T UpsertableResource](ctx context.Context, upserter U
 			return fmt.Errorf("failed to get %T: %w", obj, err)
 		}
 
+		obj.SetResourceVersion("") // Reset resource version for creation
 		if _, err := upserter.Create(ctx, obj, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create %T: %w", obj, err)
 		}

--- a/k8s/resource_test.go
+++ b/k8s/resource_test.go
@@ -78,7 +78,7 @@ func TestUpsertResource_UnsupportedResource(t *testing.T) {
 func TestUpsert_Create(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ConfigMap", func(t *testing.T) {
+	t.Run("configmap", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -100,7 +100,7 @@ func TestUpsert_Create(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("Secret", func(t *testing.T) {
+	t.Run("secret", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -146,7 +146,7 @@ func TestUpsert_Update(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("Secret", func(t *testing.T) {
+	t.Run("secret", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -170,7 +170,7 @@ func TestUpsert_Update(t *testing.T) {
 func TestUpsert_GetError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ConfigMap", func(t *testing.T) {
+	t.Run("configmap", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -193,7 +193,7 @@ func TestUpsert_GetError(t *testing.T) {
 		require.Equal(t, "failed to get *v1.ConfigMap: get error", err.Error())
 	})
 
-	t.Run("Secret", func(t *testing.T) {
+	t.Run("secret", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -220,7 +220,7 @@ func TestUpsert_GetError(t *testing.T) {
 func TestUpsert_CreateError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ConfigMap", func(t *testing.T) {
+	t.Run("configmap", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -247,7 +247,7 @@ func TestUpsert_CreateError(t *testing.T) {
 		require.Equal(t, "failed to create *v1.ConfigMap: create error", err.Error())
 	})
 
-	t.Run("Secret", func(t *testing.T) {
+	t.Run("secret", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -278,7 +278,7 @@ func TestUpsert_CreateError(t *testing.T) {
 func TestUpsert_UpdateError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ConfigMap", func(t *testing.T) {
+	t.Run("configmap", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -303,7 +303,7 @@ func TestUpsert_UpdateError(t *testing.T) {
 		require.Equal(t, "failed to update *v1.ConfigMap: update error", err.Error())
 	})
 
-	t.Run("Secret", func(t *testing.T) {
+	t.Run("secret", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()

--- a/k8s/resource_test.go
+++ b/k8s/resource_test.go
@@ -126,7 +126,7 @@ func TestUpsert_Create(t *testing.T) {
 func TestUpsert_Update(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ConfigMap", func(t *testing.T) {
+	t.Run("configmap", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()

--- a/k8s/resource_test.go
+++ b/k8s/resource_test.go
@@ -16,23 +16,49 @@ import (
 	k8stest "k8s.io/client-go/testing"
 )
 
-func TestUpsertResource_ConfigMap(t *testing.T) {
-	kubeClient := fake.NewClientset()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
+func TestUpsertResource(t *testing.T) {
+	t.Parallel()
 
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap",
-			Namespace: "default",
-		},
-	}
+	t.Run("configmap", func(t *testing.T) {
+		t.Parallel()
 
-	err := UpsertResource(ctx, kubeClient, configMap)
-	require.NoError(t, err)
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: "default",
+			},
+		}
+
+		err := UpsertResource(ctx, kubeClient, configMap)
+		require.NoError(t, err)
+	})
+
+	t.Run("secret", func(t *testing.T) {
+		t.Parallel()
+
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "default",
+			},
+		}
+
+		err := UpsertResource(ctx, kubeClient, secret)
+		require.NoError(t, err)
+	})
 }
 
 func TestUpsertResource_UnsupportedResource(t *testing.T) {
+	t.Parallel()
+
 	kubeClient := fake.NewClientset()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
@@ -50,108 +76,252 @@ func TestUpsertResource_UnsupportedResource(t *testing.T) {
 }
 
 func TestUpsert_Create(t *testing.T) {
-	kubeClient := fake.NewClientset()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
+	t.Parallel()
 
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap",
-			Namespace: "default",
-		},
-	}
+	t.Run("ConfigMap", func(t *testing.T) {
+		t.Parallel()
 
-	kubeClient.PrependReactor("get", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmaps"}, "test-configmap")
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: "default",
+			},
+		}
+
+		kubeClient.PrependReactor("get", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmaps"}, "test-configmap")
+		})
+
+		err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
+		require.NoError(t, err)
 	})
 
-	err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
-	require.NoError(t, err)
+	t.Run("Secret", func(t *testing.T) {
+		t.Parallel()
+
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "default",
+			},
+		}
+
+		kubeClient.PrependReactor("get", "secrets", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, "test-secret")
+		})
+
+		err := upsert(ctx, kubeClient.CoreV1().Secrets("default"), secret)
+		require.NoError(t, err)
+	})
 }
 
 func TestUpsert_Update(t *testing.T) {
-	kubeClient := fake.NewClientset()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
+	t.Parallel()
 
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap",
-			Namespace: "default",
-		},
-	}
+	t.Run("ConfigMap", func(t *testing.T) {
+		t.Parallel()
 
-	_, _ = kubeClient.CoreV1().ConfigMaps("default").Create(ctx, configMap, metav1.CreateOptions{})
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
 
-	err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
-	require.NoError(t, err)
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: "default",
+			},
+		}
+
+		_, _ = kubeClient.CoreV1().ConfigMaps("default").Create(ctx, configMap, metav1.CreateOptions{})
+
+		err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
+		require.NoError(t, err)
+	})
+
+	t.Run("Secret", func(t *testing.T) {
+		t.Parallel()
+
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "default",
+			},
+		}
+
+		_, _ = kubeClient.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+
+		err := upsert(ctx, kubeClient.CoreV1().Secrets("default"), secret)
+		require.NoError(t, err)
+	})
 }
 
 func TestUpsert_GetError(t *testing.T) {
-	kubeClient := fake.NewClientset()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
+	t.Parallel()
 
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap",
-			Namespace: "default",
-		},
-	}
+	t.Run("ConfigMap", func(t *testing.T) {
+		t.Parallel()
 
-	kubeClient.PrependReactor("get", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, errors.New("get error")
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: "default",
+			},
+		}
+
+		kubeClient.PrependReactor("get", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("get error")
+		})
+
+		err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
+		require.Error(t, err)
+		require.Equal(t, "failed to get *v1.ConfigMap: get error", err.Error())
 	})
 
-	err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
-	require.Error(t, err)
-	require.Equal(t, "failed to get *v1.ConfigMap: get error", err.Error())
+	t.Run("Secret", func(t *testing.T) {
+		t.Parallel()
+
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "default",
+			},
+		}
+
+		kubeClient.PrependReactor("get", "secrets", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("get error")
+		})
+
+		err := upsert(ctx, kubeClient.CoreV1().Secrets("default"), secret)
+		require.Error(t, err)
+		require.Equal(t, "failed to get *v1.Secret: get error", err.Error())
+	})
 }
 
 func TestUpsert_CreateError(t *testing.T) {
-	kubeClient := fake.NewClientset()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
+	t.Parallel()
 
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap",
-			Namespace: "default",
-		},
-	}
+	t.Run("ConfigMap", func(t *testing.T) {
+		t.Parallel()
 
-	kubeClient.PrependReactor("get", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmaps"}, "test-configmap")
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: "default",
+			},
+		}
+
+		kubeClient.PrependReactor("get", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmaps"}, "test-configmap")
+		})
+
+		kubeClient.PrependReactor("create", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("create error")
+		})
+
+		err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
+		require.Error(t, err)
+		require.Equal(t, "failed to create *v1.ConfigMap: create error", err.Error())
 	})
 
-	kubeClient.PrependReactor("create", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, errors.New("create error")
-	})
+	t.Run("Secret", func(t *testing.T) {
+		t.Parallel()
 
-	err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
-	require.Error(t, err)
-	require.Equal(t, "failed to create *v1.ConfigMap: create error", err.Error())
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "default",
+			},
+		}
+
+		kubeClient.PrependReactor("get", "secrets", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, "test-secret")
+		})
+
+		kubeClient.PrependReactor("create", "secrets", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("create error")
+		})
+
+		err := upsert(ctx, kubeClient.CoreV1().Secrets("default"), secret)
+		require.Error(t, err)
+		require.Equal(t, "failed to create *v1.Secret: create error", err.Error())
+	})
 }
 
 func TestUpsert_UpdateError(t *testing.T) {
-	kubeClient := fake.NewClientset()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
+	t.Parallel()
 
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap",
-			Namespace: "default",
-		},
-	}
+	t.Run("ConfigMap", func(t *testing.T) {
+		t.Parallel()
 
-	_, _ = kubeClient.CoreV1().ConfigMaps("default").Create(ctx, configMap, metav1.CreateOptions{})
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
 
-	kubeClient.PrependReactor("update", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, errors.New("update error")
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: "default",
+			},
+		}
+
+		_, _ = kubeClient.CoreV1().ConfigMaps("default").Create(ctx, configMap, metav1.CreateOptions{})
+
+		kubeClient.PrependReactor("update", "configmaps", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("update error")
+		})
+
+		err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
+		require.Error(t, err)
+		require.Equal(t, "failed to update *v1.ConfigMap: update error", err.Error())
 	})
 
-	err := upsert(ctx, kubeClient.CoreV1().ConfigMaps("default"), configMap)
-	require.Error(t, err)
-	require.Equal(t, "failed to update *v1.ConfigMap: update error", err.Error())
+	t.Run("Secret", func(t *testing.T) {
+		t.Parallel()
+
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "default",
+			},
+		}
+
+		_, _ = kubeClient.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+		kubeClient.PrependReactor("update", "secrets", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("update error")
+		})
+		err := upsert(ctx, kubeClient.CoreV1().Secrets("default"), secret)
+		require.EqualError(t, err, "failed to update *v1.Secret: update error")
+	})
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request enhances the `UpsertResource` functionality in the `k8s/resource.go` file by adding support for Kubernetes `Secret` resources, alongside the existing support for `ConfigMap`. It also introduces comprehensive test cases for `Secret` resources, refactors the test structure for better parallelism, and includes a minor improvement to reset resource versions during resource creation.

### Core functionality updates:
* Added support for `corev1.Secret` in the `UpsertResource` function, enabling the upsert operation for `Secret` resources. (`k8s/resource.go`, [k8s/resource.goR50-R51](diffhunk://#diff-161929b181271b887f51f81d89f6b22252e454405f9a5c0266e1c81da7ced3e3R50-R51))
* Reset the resource version to an empty string during creation to avoid conflicts. (`k8s/resource.go`, [k8s/resource.goR65](diffhunk://#diff-161929b181271b887f51f81d89f6b22252e454405f9a5c0266e1c81da7ced3e3R65))

### Testing enhancements:
* Refactored tests to use `t.Run` for subtests, enabling parallel execution and improving test organization. (`k8s/resource_test.go`, [[1]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L19-R24) [[2]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2R38-R61) [[3]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2R79-R83)
* Added test cases for `Secret` resources to cover create, update, get error, create error, and update error scenarios. (`k8s/resource_test.go`, [[1]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2R101-R131) [[2]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2R147-R175) [[3]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2R194-R225) [[4]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2R248-R283) [[5]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2R304-R326)