### PR TITLE
feat(health): adding a grace period to the checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ port `9090`. The metrics are registered with the `prometheus` package and are ex
 
 If you want to add health checks that state whether the application is healthy or not, you can use the
 `web.WithHealthCheck` option. This option will take a list of health checks that will be run whenever the health check
-endpoint is hit. There is **_NO_** specific endpoint for the health check, it is just the port that is exposed. If you
-provide a path, it is re-routed to the `/` endpoint.
+endpoint is hit. The health checks get setup on the routes `/readyz` and `/livez`; this allows for Kubernetes to check 
+the health of the application and determine is the application is ready to serve traffic or not.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ port `9090`. The metrics are registered with the `prometheus` package and are ex
 If you want to add health checks that state whether the application is healthy or not, you can use the
 `web.WithHealthCheck` option. This option will take a list of health checks that will be run whenever the health check
 endpoint is hit. The health checks get setup on the routes `/readyz` and `/livez`; this allows for Kubernetes to check 
-the health of the application and determine is the application is ready to serve traffic or not.
+the health of the application and determine if the application is ready to serve traffic or not.
 
 ### Options
 

--- a/app.go
+++ b/app.go
@@ -27,7 +27,6 @@ import (
 	"github.com/jacobbrewer1/vaulty"
 	"github.com/jacobbrewer1/vaulty/vsql"
 	"github.com/jacobbrewer1/web/cache"
-	"github.com/jacobbrewer1/web/health"
 	"github.com/jacobbrewer1/web/logging"
 	"github.com/jacobbrewer1/web/version"
 	"github.com/jacobbrewer1/workerpool"
@@ -75,12 +74,6 @@ type (
 
 		// baseCfg is the base configuration for the application.
 		baseCfg *AppConfig
-
-		// healthReadyCheck is the health check function to indicate if the application is ready.
-		healthReadyCheck *health.Checker
-
-		// healthLiveCheck is the health check function to indicate if the application is live.
-		healthLiveCheck *health.Checker
 
 		// isStartedChan is a channel that is closed when the application is started.
 		isStartedChan chan struct{}

--- a/app.go
+++ b/app.go
@@ -77,10 +77,10 @@ type (
 		baseCfg *AppConfig
 
 		// healthReadyCheck is the health check function to indicate if the application is ready.
-		healthReadyCheck health.Checker
+		healthReadyCheck *health.Checker
 
 		// healthLiveCheck is the health check function to indicate if the application is live.
-		healthLiveCheck health.Checker
+		healthLiveCheck *health.Checker
 
 		// isStartedChan is a channel that is closed when the application is started.
 		isStartedChan chan struct{}

--- a/app.go
+++ b/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jacobbrewer1/vaulty"
 	"github.com/jacobbrewer1/vaulty/vsql"
 	"github.com/jacobbrewer1/web/cache"
+	"github.com/jacobbrewer1/web/health"
 	"github.com/jacobbrewer1/web/logging"
 	"github.com/jacobbrewer1/web/version"
 	"github.com/jacobbrewer1/workerpool"
@@ -74,6 +75,12 @@ type (
 
 		// baseCfg is the base configuration for the application.
 		baseCfg *AppConfig
+
+		// healthReadyCheck is the health check function to indicate if the application is ready.
+		healthReadyCheck health.Checker
+
+		// healthLiveCheck is the health check function to indicate if the application is live.
+		healthLiveCheck health.Checker
 
 		// isStartedChan is a channel that is closed when the application is started.
 		isStartedChan chan struct{}

--- a/health/checker.go
+++ b/health/checker.go
@@ -29,7 +29,7 @@ type Checker struct {
 	// firstFailInCycle is the timestamp of the first failure in the current cycle.
 	firstFailInCycle atomic.Value
 
-	// errorGracePeriod is the time period in seconds during which errors are tolerated.
+	// errorGracePeriod is the time.Duration during which errors are tolerated.
 	errorGracePeriod time.Duration
 }
 

--- a/health/checker_options.go
+++ b/health/checker_options.go
@@ -1,6 +1,9 @@
 package health
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // CheckerOption defines a function type that modifies a Checker instance.
 type CheckerOption func(*Checker) error
@@ -41,6 +44,14 @@ func WithCheckerHTTPCodeUp(code int) CheckerOption {
 func WithCheckerHTTPCodeDown(code int) CheckerOption {
 	return func(c *Checker) error {
 		c.httpStatusCodeDown = code
+		return nil
+	}
+}
+
+// WithCheckerErrorGracePeriod sets the grace period for errors. This will ignore errors from any checks.
+func WithCheckerErrorGracePeriod(gracePeriod time.Duration) CheckerOption {
+	return func(c *Checker) error {
+		c.errorGracePeriod = gracePeriod
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -225,7 +225,7 @@ func WithHealthCheck(checks ...*health.Check) StartOption {
 			return fmt.Errorf("error creating health checker: %w", err)
 		}
 
-		livenessChecker, err := health.NewChecker()
+		livenessChecker, err := health.NewChecker(health.WithCheckerErrorGracePeriod(10 * time.Second))
 		if err != nil {
 			return fmt.Errorf("error creating liveness checker: %w", err)
 		}

--- a/options.go
+++ b/options.go
@@ -245,7 +245,7 @@ func WithHealthCheck(checks ...*health.Check) StartOption {
 
 		r := mux.NewRouter()
 		r.Handle("/readyz", readinessChecker.Handler()).Methods(http.MethodGet)
-		r.Handle("/healthz", livenessChecker.Handler()).Methods(http.MethodGet)
+		r.Handle("/livez", livenessChecker.Handler()).Methods(http.MethodGet)
 		a.servers.Store("health", &http.Server{
 			Addr:              fmt.Sprintf(":%d", HealthPort),
 			Handler:           r,

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/gomodule/redigo/redis"
+	"github.com/gorilla/mux"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/spf13/viper"
@@ -219,23 +220,34 @@ func WithHealthCheck(checks ...*health.Check) StartOption {
 			return errors.New("health check server already registered")
 		}
 
-		checker, err := health.NewChecker()
+		readinessChecker, err := health.NewChecker()
 		if err != nil {
 			return fmt.Errorf("error creating health checker: %w", err)
 		}
 
+		livenessChecker, err := health.NewChecker()
+		if err != nil {
+			return fmt.Errorf("error creating liveness checker: %w", err)
+		}
+
 		for _, check := range checks {
-			if err := checker.AddCheck(check); err != nil {
+			if err := readinessChecker.AddCheck(check); err != nil {
 				return fmt.Errorf("error adding health check %s: %w", check.String(), err)
+			}
+
+			if err := livenessChecker.AddCheck(check); err != nil {
+				return fmt.Errorf("error adding liveness check %s: %w", check.String(), err)
 			}
 		}
 
+		r := mux.NewRouter()
+		r.Handle("/readyz", readinessChecker.Handler()).Methods(http.MethodGet)
+		r.Handle("/healthz", livenessChecker.Handler()).Methods(http.MethodGet)
 		a.servers.Store("health", &http.Server{
 			Addr:              fmt.Sprintf(":%d", HealthPort),
-			Handler:           checker.Handler(),
+			Handler:           r,
 			ReadHeaderTimeout: httpReadHeaderTimeout,
 		})
-
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -220,11 +220,14 @@ func WithHealthCheck(checks ...*health.Check) StartOption {
 			return errors.New("health check server already registered")
 		}
 
+		// No grace period as we do not want to receive any traffic the moment the pod health check fails.
 		readinessChecker, err := health.NewChecker()
 		if err != nil {
 			return fmt.Errorf("error creating health checker: %w", err)
 		}
 
+		// Setting a grace period for liveness checks as Kubernetes will kill the pod
+		// if the liveness check fails. This allows for a grace period before the pod is killed.
 		livenessChecker, err := health.NewChecker(health.WithCheckerErrorGracePeriod(10 * time.Second))
 		if err != nil {
 			return fmt.Errorf("error creating liveness checker: %w", err)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces several enhancements and changes to the health check system, including support for readiness and liveness probes, an error grace period for health checks, and improved test coverage. These changes aim to make the health checks more robust and Kubernetes-friendly.

### Health Check Enhancements:
* Updated the health check endpoints to include `/readyz` and `/livez`, allowing Kubernetes to distinguish between readiness and liveness probes. (`README.md`, [README.mdL136-R137](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L136-R137))
* Added an error grace period feature to tolerate transient failures. This includes a new `WithCheckerErrorGracePeriod` option and logic in the `Checker` struct to handle the grace period. (`health/checker.go`, [[1]](diffhunk://#diff-a7307efb619b1e13332a984622b29e0f17352bccb59dc3df84ce33e12d56c3b1R28-R33) [[2]](diffhunk://#diff-a7307efb619b1e13332a984622b29e0f17352bccb59dc3df84ce33e12d56c3b1R94-R120); `health/checker_options.go`, [[3]](diffhunk://#diff-8549d9d6ec584054aedb25af03fab65890b536b55d2b82689fb7f08a352090a2R50-R57)

### Codebase Updates:
* Updated the `WithHealthCheck` function to use separate `readinessChecker` and `livenessChecker` instances, with different grace period configurations. (`options.go`, [options.goL222-L238](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L222-L238))
* Integrated the `gorilla/mux` router to handle the new health check endpoints. (`options.go`, [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R13) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L222-L238)

### Test Improvements:
* Added unit tests for the new error grace period functionality, including scenarios for within and outside the grace period, as well as multiple async checks. (`health/checker_test.go`, [health/checker_test.goR335-R412](diffhunk://#diff-b34a9fde0fea4438a9aa024a22b7ca2e7b8ff4a2e2c1f59034e9cb043d617755R335-R412))
* Extended existing tests to validate the behavior of the new health check endpoints. (`health/checker_test.go`, [[1]](diffhunk://#diff-b34a9fde0fea4438a9aa024a22b7ca2e7b8ff4a2e2c1f59034e9cb043d617755R30) [[2]](diffhunk://#diff-b34a9fde0fea4438a9aa024a22b7ca2e7b8ff4a2e2c1f59034e9cb043d617755R55-R82)