### PR TITLE
feat(cache): adding benchmark to the on endpoint update function

### DIFF
--- a/cache/service_endpoint_hash_bucket_test.go
+++ b/cache/service_endpoint_hash_bucket_test.go
@@ -392,7 +392,7 @@ func Benchmark_OnEndpointUpdate(b *testing.B) {
 		thisPod:      k8s.PodName(),
 	}
 
-	newUUID := func() string {
+	newUUIDInHashRing := func() string {
 		uid := uuid.New().String()
 		sb.hr.AddNode(uid)
 		return uid
@@ -415,13 +415,13 @@ func Benchmark_OnEndpointUpdate(b *testing.B) {
 					{
 						TargetRef: &corev1.ObjectReference{
 							Kind: "Pod",
-							Name: newUUID(),
+							Name: newUUIDInHashRing(),
 						},
 					},
 					{
 						TargetRef: &corev1.ObjectReference{
 							Kind: "Pod",
-							Name: newUUID(),
+							Name: newUUIDInHashRing(),
 						},
 					},
 				},

--- a/cache/service_endpoint_hash_bucket_test.go
+++ b/cache/service_endpoint_hash_bucket_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/serialx/hashring"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -379,6 +380,75 @@ func Test_endpointSliceToSet(t *testing.T) {
 			},
 		),
 	)
+}
+
+func Benchmark_OnEndpointUpdate(b *testing.B) {
+	sb := &ServiceEndpointHashBucket{
+		mut:          new(sync.RWMutex),
+		l:            slog.New(slog.DiscardHandler),
+		hr:           hashring.New([]string{}),
+		appName:      "my-app-name",
+		appNamespace: k8s.DeployedNamespace(),
+		thisPod:      k8s.PodName(),
+	}
+
+	newUUID := func() string {
+		uid := uuid.New().String()
+		sb.hr.AddNode(uid)
+		return uid
+	}
+
+	b.ResetTimer()
+
+	for range b.N {
+		sb.onEndpointUpdate(
+			&discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "my-app-name-n4wmx",
+					Namespace:    k8s.DeployedNamespace(),
+					GenerateName: "my-app-name-",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "my-app-name",
+					},
+				},
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						TargetRef: &corev1.ObjectReference{
+							Kind: "Pod",
+							Name: newUUID(),
+						},
+					},
+					{
+						TargetRef: &corev1.ObjectReference{
+							Kind: "Pod",
+							Name: newUUID(),
+						},
+					},
+				},
+			},
+			&discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "my-app-name-n4wmx",
+					Namespace:    k8s.DeployedNamespace(),
+					GenerateName: "my-app-name-",
+				},
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						TargetRef: &corev1.ObjectReference{
+							Kind: "Pod",
+							Name: uuid.New().String(),
+						},
+					},
+					{
+						TargetRef: &corev1.ObjectReference{
+							Kind: "Pod",
+							Name: uuid.New().String(),
+						},
+					},
+				},
+			},
+		)
+	}
 }
 
 func Test_InBucket_WithoutStart(t *testing.T) {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces a new benchmark test to evaluate the performance of the `onEndpointUpdate` method in the `ServiceEndpointHashBucket` class. Additionally, a new dependency on the `uuid` package was added to generate unique identifiers for testing purposes.

### Benchmarking improvements:
* Added a new `Benchmark_OnEndpointUpdate` function to measure the performance of the `onEndpointUpdate` method. This includes creating a `ServiceEndpointHashBucket` instance, generating unique identifiers using `uuid`, and simulating updates to Kubernetes `EndpointSlice` objects. (`cache/service_endpoint_hash_bucket_test.go`, [cache/service_endpoint_hash_bucket_test.goR385-R453](diffhunk://#diff-a4c64fb14c304c0df4e42d6e0a4311cb19b1b542cf2be946a4f1d729ec2b7cbfR385-R453))

### Dependency updates:
* Imported the `github.com/google/uuid` package to generate UUIDs for use in the new benchmark test. (`cache/service_endpoint_hash_bucket_test.go`, [cache/service_endpoint_hash_bucket_test.goR10](diffhunk://#diff-a4c64fb14c304c0df4e42d6e0a4311cb19b1b542cf2be946a4f1d729ec2b7cbfR10))