### PR TITLE
chore(cache): start once for service endpoint cache

### DIFF
--- a/cache/fixed_hash_bucket.go
+++ b/cache/fixed_hash_bucket.go
@@ -10,7 +10,7 @@ import (
 //
 // This line is a compile-time check to guarantee that FixedHashBucket
 // satisfies all the methods defined in the HashBucket interface.
-var _ HashBucket = new(FixedHashBucket)
+var _ HashBucket = (*FixedHashBucket)(nil)
 
 // FixedHashBucket represents a mechanism for determining whether supplied keys belong to the current bucket index.
 // It uses a consistent hashing ring to distribute keys across buckets based on their hash values.

--- a/cache/service_endpoint_hash_bucket.go
+++ b/cache/service_endpoint_hash_bucket.go
@@ -26,7 +26,7 @@ const (
 )
 
 // Ensures that ServiceEndpointHashBucket implements the HashBucket interface.
-var _ HashBucket = new(ServiceEndpointHashBucket)
+var _ HashBucket = (*ServiceEndpointHashBucket)(nil)
 
 // ServiceEndpointHashBucket represents a mechanism which determines whether the current application instance should process
 // a particular key. The bucket size is determined by the number of active endpoints in the supplied Kubernetes service.

--- a/cache/service_endpoint_hash_bucket.go
+++ b/cache/service_endpoint_hash_bucket.go
@@ -34,6 +34,9 @@ type ServiceEndpointHashBucket struct {
 	// mut is a read-write mutex used to ensure thread-safe access to the hash ring and other shared resources.
 	mut *sync.RWMutex
 
+	// startOnce is a sync.Once instance used to ensure that the Start method is only called once.
+	startOnce sync.Once
+
 	// hr represents the consistent hash ring used to distribute keys among application instances.
 	hr *hashring.HashRing
 
@@ -86,46 +89,54 @@ func (sb *ServiceEndpointHashBucket) Start(ctx context.Context) error {
 		return errors.New("context cannot be nil")
 	}
 
-	// Get the initial list of endpoint slices for the application
-	endpointSliceList, err := sb.kubeClient.DiscoveryV1().EndpointSlices(sb.appNamespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", k8sNameLabel, sb.appName),
-	})
-	if err != nil {
-		return fmt.Errorf("error getting initial endpoints: %w", err)
-	} else if len(endpointSliceList.Items) == 0 {
-		return fmt.Errorf("no endpoint slices found for app %s in namespace %s", sb.appName, sb.appNamespace)
-	}
-
-	// Combine all endpoints from all slices into a single set
-	currentHostSet := slices.NewSet[string]()
-	for i := range endpointSliceList.Items {
-		endpointSlice := &endpointSliceList.Items[i]
-		sliceHosts := endpointSliceToSet(endpointSlice)
-		sliceHosts.Each(func(host string) {
-			currentHostSet.Add(host)
+	var startErr error
+	sb.startOnce.Do(func() {
+		// Get the initial list of endpoint slices for the application
+		endpointSliceList, err := sb.kubeClient.DiscoveryV1().EndpointSlices(sb.appNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", k8sNameLabel, sb.appName),
 		})
-	}
+		if err != nil {
+			startErr = fmt.Errorf("error listing endpoint slices: %w", err)
+			return
+		} else if len(endpointSliceList.Items) == 0 {
+			startErr = fmt.Errorf("no endpoint slices found for application %s in namespace %s", sb.appName, sb.appNamespace)
+			return
+		}
 
-	sb.l.Info("initialising hash ring with hosts", slog.Any(logging.KeyHosts, currentHostSet.Items()))
+		// Combine all endpoints from all slices into a single set
+		currentHostSet := slices.NewSet[string]()
+		for i := range endpointSliceList.Items {
+			endpointSlice := &endpointSliceList.Items[i]
+			sliceHosts := endpointSliceToSet(endpointSlice)
+			sliceHosts.Each(func(host string) {
+				currentHostSet.Add(host)
+			})
+		}
 
-	// Lock the mutex to ensure thread-safe access to the hash ring
-	sb.mut.Lock()
-	defer sb.mut.Unlock()
+		sb.l.Info("initialising hash ring with hosts", slog.Any(logging.KeyHosts, currentHostSet.Items()))
 
-	// Initialize the hash ring with the current set of hosts
-	sb.hr = hashring.New(currentHostSet.Items())
+		// Lock the mutex to ensure thread-safe access to the hash ring
+		sb.mut.Lock()
+		defer sb.mut.Unlock()
 
-	// Start the shared informer factory to monitor changes in endpoint slices and wait for cache sync
-	sb.informerFactory.Start(ctx.Done())
-	sb.informerFactory.WaitForCacheSync(ctx.Done())
+		// Initialize the hash ring with the current set of hosts
+		sb.hr = hashring.New(currentHostSet.Items())
 
-	// Add an event handler to the endpoints informer to handle updates to endpoint slices
-	if _, err := sb.endpointsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: sb.onEndpointUpdate,
-	}); err != nil {
-		return fmt.Errorf("error adding event handler to endpoints informer: %w", err)
-	}
-	return nil
+		// Start the shared informer factory to monitor changes in endpoint slices and wait for cache sync
+		sb.informerFactory.Start(ctx.Done())
+		sb.informerFactory.WaitForCacheSync(ctx.Done())
+
+		// Add an event handler to the endpoints informer to handle updates to endpoint slices
+		if _, err := sb.endpointsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			UpdateFunc: sb.onEndpointUpdate,
+		}); err != nil {
+			startErr = fmt.Errorf("error adding event handler to endpoints informer: %w", err)
+			return
+		}
+
+		startErr = nil
+	})
+	return startErr
 }
 
 // InBucket checks if the given key is assigned to the current application instance

--- a/logging/dedupe_handler.go
+++ b/logging/dedupe_handler.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Ensure dedupeHandler implements the slog.Handler interface.
-var _ slog.Handler = new(dedupeHandler)
+var _ slog.Handler = (*dedupeHandler)(nil)
 
 // dedupeHandler is a custom slog.Handler that deduplicates attributes.
 type dedupeHandler struct {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes updates to improve thread safety, error handling, and type assertion practices across multiple files. The most significant changes involve introducing a `sync.Once` mechanism to ensure the `Start` method is only executed once in `ServiceEndpointHashBucket`, improving error handling in the same method, and updating type assertion syntax for consistency.

### Thread safety improvements:
* Added a `sync.Once` instance (`startOnce`) to `ServiceEndpointHashBucket` to ensure the `Start` method is executed only once. This prevents potential race conditions when initializing the hash bucket. (`cache/service_endpoint_hash_bucket.go`, [cache/service_endpoint_hash_bucket.goL29-R39](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9L29-R39))

### Error handling enhancements:
* Refactored the `Start` method in `ServiceEndpointHashBucket` to use `startErr` for consistent error propagation within the `sync.Once` block. This ensures that errors encountered during initialization are properly returned. (`cache/service_endpoint_hash_bucket.go`, [[1]](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9R92-R103) [[2]](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9L126-R139)

### Type assertion consistency:
* Updated type assertions for `FixedHashBucket`, `ServiceEndpointHashBucket`, and `dedupeHandler` to use the `(*Type)(nil)` pattern instead of `new(Type)`. This is a more idiomatic approach in Go for ensuring interface compliance. (`cache/fixed_hash_bucket.go`, [[1]](diffhunk://#diff-2687a439f7145a5ba37793ba16c56c7900137ca8126ad69e74147a4b7796bf26L13-R13); `cache/service_endpoint_hash_bucket.go`, [[2]](diffhunk://#diff-f0036b631f291b5541037862f3c7e45eecad8d23360087fd1a01b24edf55a8e9L29-R39); `logging/dedupe_handler.go`, [[3]](diffhunk://#diff-5060370d65295a9a13abd32f75b5f91f5bb1cc2090f1f58efec4012e2dcd1600L9-R9)