### PR TITLE
chore(app): tidying up a few tests

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -129,7 +129,7 @@ func TestApp_StartServer(t *testing.T) {
 
 	// Try and start the same server again
 	err = app.StartServer("test1", svr1)
-	require.Error(t, err)
+	require.EqualError(t, err, "server test1 already exists")
 }
 
 func TestApp_ChildContext(t *testing.T) {

--- a/health/result_test.go
+++ b/health/result_test.go
@@ -126,6 +126,7 @@ func TestResult_AddDetail(t *testing.T) {
 	t.Parallel()
 
 	t.Run("AddDetail with nil Result", func(t *testing.T) {
+		t.Parallel()
 		res := new(Result)
 		res.mtx = new(sync.RWMutex)
 

--- a/health/result_test.go
+++ b/health/result_test.go
@@ -122,16 +122,18 @@ func TestResult_SetStatusOverride(t *testing.T) {
 	}
 }
 
-func TestResult_AddDetail_NilMap(t *testing.T) {
+func TestResult_AddDetail(t *testing.T) {
 	t.Parallel()
 
-	res := new(Result)
-	res.mtx = new(sync.RWMutex)
+	t.Run("AddDetail with nil Result", func(t *testing.T) {
+		res := new(Result)
+		res.mtx = new(sync.RWMutex)
 
-	require.NotPanics(t, func() {
-		res.addDetail("test", &Result{Status: StatusUp})
+		require.NotPanics(t, func() {
+			res.addDetail("test", &Result{Status: StatusUp})
+		})
+
+		require.NotNil(t, res.Details, "Details map should be initialized")
+		require.Len(t, res.Details, 1)
 	})
-
-	require.NotNil(t, res.Details, "Details map should be initialized")
-	require.Len(t, res.Details, 1)
 }

--- a/logging/config_test.go
+++ b/logging/config_test.go
@@ -18,7 +18,6 @@ func setEnv(t *testing.T, key, val string) {
 }
 
 func TestNewLoggingConfig(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name string
 		env  map[string]string
@@ -80,8 +79,6 @@ func TestNewLoggingConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			if tt.env != nil {
 				for k, v := range tt.env {
 					setEnv(t, k, v)

--- a/logging/config_test.go
+++ b/logging/config_test.go
@@ -18,6 +18,7 @@ func setEnv(t *testing.T, key, val string) {
 }
 
 func TestNewLoggingConfig(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		env  map[string]string
@@ -79,6 +80,8 @@ func TestNewLoggingConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if tt.env != nil {
 				for k, v := range tt.env {
 					setEnv(t, k, v)

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -152,9 +152,11 @@ func BenchmarkReplaceAttrs(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for range b.N {
-				replaceAttrs(nil, bm.attr)
-			}
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					replaceAttrs(nil, bm.attr)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request focuses on improving test coverage, enhancing test clarity, and optimizing parallel execution in the codebase. The most significant changes include refining error assertions, restructuring test cases for better readability, enabling parallelism in tests, and optimizing a benchmark function for concurrent execution.

### Improvements to test clarity and assertions:
* [`app_test.go`](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL132-R132): Updated the error assertion in `TestApp_StartServer` to use `require.EqualError` for a more descriptive error message when a server already exists.
* [`health/result_test.go`](diffhunk://#diff-f55ca2d9d10e27b92eea734c9658a70e1fd2c427dab4c6b8eab36cfc1cf2e0fdL125-R128): Renamed `TestResult_AddDetail_NilMap` to `TestResult_AddDetail` and added a subtest to handle cases where the `Result` object is nil, improving test case organization and readability. [[1]](diffhunk://#diff-f55ca2d9d10e27b92eea734c9658a70e1fd2c427dab4c6b8eab36cfc1cf2e0fdL125-R128) [[2]](diffhunk://#diff-f55ca2d9d10e27b92eea734c9658a70e1fd2c427dab4c6b8eab36cfc1cf2e0fdR138)

### Enhancements to parallelism in tests:
* [`logging/config_test.go`](diffhunk://#diff-d04d93a453da02a9f4fbf31e6d10699b2fff32af6647de10a6540087ac006ee8R21): Added `t.Parallel()` to `TestNewLoggingConfig` and its subtests to enable concurrent execution, improving test performance. [[1]](diffhunk://#diff-d04d93a453da02a9f4fbf31e6d10699b2fff32af6647de10a6540087ac006ee8R21) [[2]](diffhunk://#diff-d04d93a453da02a9f4fbf31e6d10699b2fff32af6647de10a6540087ac006ee8R83-R84)

### Optimization in benchmark execution:
* [`logging/logger_test.go`](diffhunk://#diff-592d08cada4c87bd69e20d3eb1ac3b8d11c5482053528d03dd511611dcc9e517L155-R160): Modified the `BenchmarkReplaceAttrs` function to use `b.RunParallel`, allowing concurrent execution of benchmark iterations for better performance testing.