### PR TITLE
chore(tests): updating the test strategy to be more parrallel

### DIFF
--- a/cache/fixed_hash_bucket_test.go
+++ b/cache/fixed_hash_bucket_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func Test_FixedHashBucket(t *testing.T) {
+	t.Parallel()
+	
 	h := NewFixedHashBucket(2)
 	v := "hello"
 

--- a/cache/fixed_hash_bucket_test.go
+++ b/cache/fixed_hash_bucket_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test_FixedHashBucket(t *testing.T) {
 	t.Parallel()
-	
+
 	h := NewFixedHashBucket(2)
 	v := "hello"
 

--- a/health/result_test.go
+++ b/health/result_test.go
@@ -21,10 +21,6 @@ func compareResult(t *testing.T, expected, actual *Result) {
 	require.Equal(t, expected.Error, actual.Error, "Error mismatch: expected %v, got %v", expected.Error, actual.Error)
 
 	require.Len(t, expected.Details, len(actual.Details), "Details length mismatch: expected %d, got %d", len(expected.Details), len(actual.Details))
-
-	if len(expected.Details) != len(actual.Details) {
-		t.Fatalf("Details length mismatch: expected %d, got %d", len(expected.Details), len(actual.Details))
-	}
 	for k := range expected.Details {
 		compareResult(t, expected.Details[k], actual.Details[k])
 	}

--- a/health/result_test.go
+++ b/health/result_test.go
@@ -22,6 +22,9 @@ func compareResult(t *testing.T, expected, actual *Result) {
 
 	require.Len(t, expected.Details, len(actual.Details), "Details length mismatch: expected %d, got %d", len(expected.Details), len(actual.Details))
 
+	if len(expected.Details) != len(actual.Details) {
+		t.Fatalf("Details length mismatch: expected %d, got %d", len(expected.Details), len(actual.Details))
+	}
 	for k := range expected.Details {
 		compareResult(t, expected.Details[k], actual.Details[k])
 	}

--- a/k8s/resource_test.go
+++ b/k8s/resource_test.go
@@ -54,31 +54,27 @@ func TestUpsertResource(t *testing.T) {
 		err := UpsertResource(ctx, kubeClient, secret)
 		require.NoError(t, err)
 	})
-}
 
-func TestUpsertResource_UnsupportedResource(t *testing.T) {
-	t.Parallel()
+	t.Run("unsupported resource", func(t *testing.T) {
+		t.Parallel()
 
-	kubeClient := fake.NewClientset()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
+		kubeClient := fake.NewClientset()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
 
-	unsupportedResource := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "default",
-		},
-	}
+		unsupportedResource := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+		}
 
-	err := UpsertResource(ctx, kubeClient, unsupportedResource)
-	require.Error(t, err)
-	require.Equal(t, "unsupported resource type: *v1.Pod", err.Error())
-}
+		err := UpsertResource(ctx, kubeClient, unsupportedResource)
+		require.Error(t, err)
+		require.Equal(t, "unsupported resource type: *v1.Pod", err.Error())
+	})
 
-func TestUpsert_Create(t *testing.T) {
-	t.Parallel()
-
-	t.Run("configmap", func(t *testing.T) {
+	t.Run("create configmap", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -100,7 +96,7 @@ func TestUpsert_Create(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("secret", func(t *testing.T) {
+	t.Run("create secret", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -121,12 +117,8 @@ func TestUpsert_Create(t *testing.T) {
 		err := upsert(ctx, kubeClient.CoreV1().Secrets("default"), secret)
 		require.NoError(t, err)
 	})
-}
 
-func TestUpsert_Update(t *testing.T) {
-	t.Parallel()
-
-	t.Run("configmap", func(t *testing.T) {
+	t.Run("update configmap", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -146,7 +138,7 @@ func TestUpsert_Update(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("secret", func(t *testing.T) {
+	t.Run("update secret", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -165,12 +157,8 @@ func TestUpsert_Update(t *testing.T) {
 		err := upsert(ctx, kubeClient.CoreV1().Secrets("default"), secret)
 		require.NoError(t, err)
 	})
-}
 
-func TestUpsert_GetError(t *testing.T) {
-	t.Parallel()
-
-	t.Run("configmap", func(t *testing.T) {
+	t.Run("get configmap error", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -193,7 +181,7 @@ func TestUpsert_GetError(t *testing.T) {
 		require.Equal(t, "failed to get *v1.ConfigMap: get error", err.Error())
 	})
 
-	t.Run("secret", func(t *testing.T) {
+	t.Run("get secret error", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -215,12 +203,8 @@ func TestUpsert_GetError(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, "failed to get *v1.Secret: get error", err.Error())
 	})
-}
 
-func TestUpsert_CreateError(t *testing.T) {
-	t.Parallel()
-
-	t.Run("configmap", func(t *testing.T) {
+	t.Run("create configmap error", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -247,7 +231,7 @@ func TestUpsert_CreateError(t *testing.T) {
 		require.Equal(t, "failed to create *v1.ConfigMap: create error", err.Error())
 	})
 
-	t.Run("secret", func(t *testing.T) {
+	t.Run("create secret error", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -273,12 +257,8 @@ func TestUpsert_CreateError(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, "failed to create *v1.Secret: create error", err.Error())
 	})
-}
 
-func TestUpsert_UpdateError(t *testing.T) {
-	t.Parallel()
-
-	t.Run("configmap", func(t *testing.T) {
+	t.Run("update configmap error", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()
@@ -303,7 +283,7 @@ func TestUpsert_UpdateError(t *testing.T) {
 		require.Equal(t, "failed to update *v1.ConfigMap: update error", err.Error())
 	})
 
-	t.Run("secret", func(t *testing.T) {
+	t.Run("update secret error", func(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := fake.NewClientset()

--- a/logging/config_test.go
+++ b/logging/config_test.go
@@ -2,20 +2,10 @@ package logging
 
 import (
 	"log/slog"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func setEnv(t *testing.T, key, val string) {
-	t.Helper()
-
-	t.Setenv(key, val)
-	t.Cleanup(func() {
-		require.NoError(t, os.Unsetenv(key))
-	})
-}
 
 func TestNewLoggingConfig(t *testing.T) {
 	tests := []struct {
@@ -81,7 +71,7 @@ func TestNewLoggingConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != nil {
 				for k, v := range tt.env {
-					setEnv(t, k, v)
+					t.Setenv(k, v)
 				}
 			}
 

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -9,34 +9,41 @@ import (
 )
 
 func TestNewLogger(t *testing.T) {
-	buf := new(bytes.Buffer)
-	l := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
-	l.Info("test")
+	t.Parallel()
 
-	got := buf.String()
+	t.Run("default logger", func(t *testing.T) {
+		t.Parallel()
+		buf := new(bytes.Buffer)
+		l := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+		l.Info("test")
 
-	require.Contains(t, got, `"app":"test"`)
-	require.Contains(t, got, `"component":"test-component"`)
-	require.Contains(t, got, `"level":"INFO"`)
-}
+		got := buf.String()
 
-func TestNewLogger_With(t *testing.T) {
-	buf := new(bytes.Buffer)
-	l := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
-	l = l.With(
-		slog.String(KeyHandler, "test-handler"),
-	)
-	l.Info("test")
+		require.Contains(t, got, `"app":"test"`)
+		require.Contains(t, got, `"component":"test-component"`)
+		require.Contains(t, got, `"level":"INFO"`)
+	})
 
-	got := buf.String()
+	t.Run("with custom attributes", func(t *testing.T) {
+		t.Parallel()
+		buf := new(bytes.Buffer)
+		l := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
+		l = l.With(
+			slog.String(KeyHandler, "test-handler"),
+		)
+		l.Info("test")
 
-	require.Contains(t, got, `"app":"test"`)
-	require.Contains(t, got, `"component":"test-component"`)
-	require.Contains(t, got, `"level":"INFO"`)
-	require.Contains(t, got, `"handler":"test-handler"`)
+		got := buf.String()
+
+		require.Contains(t, got, `"app":"test"`)
+		require.Contains(t, got, `"component":"test-component"`)
+		require.Contains(t, got, `"level":"INFO"`)
+		require.Contains(t, got, `"handler":"test-handler"`)
+	})
 }
 
 func TestDuplicateKey(t *testing.T) {
+	t.Parallel()
 	buf := new(bytes.Buffer)
 	l := NewLoggerWithWriter(buf, WithAppName("test"), WithComponent("test-component"))
 	l = LoggerWithComponent(l, "test-component-2") // This will duplicate the component key

--- a/slices/set_test.go
+++ b/slices/set_test.go
@@ -16,57 +16,57 @@ func Test_NewSet(t *testing.T) {
 	)
 }
 
-func Test_Set_Difference(t *testing.T) {
+func Test_Set(t *testing.T) {
 	t.Parallel()
 
-	a := NewSet(1, 2, 3, 4, 5)
-	b := NewSet(1, 3, 4)
+	t.Run("Difference", func(t *testing.T) {
+		t.Parallel()
+		a := NewSet(1, 2, 3, 4, 5)
+		b := NewSet(1, 3, 4)
 
-	require.Equal(
-		t,
-		NewSet(2, 5),
-		a.Difference(b),
-	)
-}
-
-func Test_Set_Items(t *testing.T) {
-	t.Parallel()
-
-	a := NewSet(1, 2, 3, 4, 5)
-	items := a.Items()
-	require.Len(t, items, 5)
-	require.Contains(t, items, 1)
-	require.Contains(t, items, 2)
-	require.Contains(t, items, 3)
-	require.Contains(t, items, 4)
-	require.Contains(t, items, 5)
-}
-
-func Test_Set_Each(t *testing.T) {
-	t.Parallel()
-
-	items := make([]int, 0)
-	NewSet(1, 2, 3, 4, 5).Each(func(item int) {
-		items = append(items, item)
+		require.Equal(
+			t,
+			NewSet(2, 5),
+			a.Difference(b),
+		)
 	})
 
-	require.Len(t, items, 5)
-	require.Contains(t, items, 1)
-	require.Contains(t, items, 2)
-	require.Contains(t, items, 3)
-	require.Contains(t, items, 4)
-	require.Contains(t, items, 5)
-}
+	t.Run("Items", func(t *testing.T) {
+		t.Parallel()
+		a := NewSet(1, 2, 3, 4, 5)
+		items := a.Items()
+		require.Len(t, items, 5)
+		require.Contains(t, items, 1)
+		require.Contains(t, items, 2)
+		require.Contains(t, items, 3)
+		require.Contains(t, items, 4)
+		require.Contains(t, items, 5)
+	})
 
-func Test_Set_Union(t *testing.T) {
-	t.Parallel()
+	t.Run("Each", func(t *testing.T) {
+		t.Parallel()
+		items := make([]int, 0)
+		NewSet(1, 2, 3, 4, 5).Each(func(item int) {
+			items = append(items, item)
+		})
 
-	a := NewSet(1, 2, 3, 4, 5)
-	b := NewSet(1, 3, 4, 6)
+		require.Len(t, items, 5)
+		require.Contains(t, items, 1)
+		require.Contains(t, items, 2)
+		require.Contains(t, items, 3)
+		require.Contains(t, items, 4)
+		require.Contains(t, items, 5)
+	})
 
-	require.Equal(
-		t,
-		NewSet(1, 2, 3, 4, 5, 6),
-		a.Union(b),
-	)
+	t.Run("Union", func(t *testing.T) {
+		t.Parallel()
+		a := NewSet(1, 2, 3, 4, 5)
+		b := NewSet(1, 3, 4, 6)
+
+		require.Equal(
+			t,
+			NewSet(1, 2, 3, 4, 5, 6),
+			a.Union(b),
+		)
+	})
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request primarily focuses on improving test organization and parallelization across multiple files. It introduces subtests for better readability and structure, removes redundant helper methods, and ensures tests run in parallel where applicable.

### Test organization improvements:

* [`k8s/resource_test.go`](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L57-R58): Consolidated multiple test functions into subtests using `t.Run` for better organization and readability. Updated test names to reflect specific scenarios, such as "create configmap error" and "update secret error". [[1]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L57-R58) [[2]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L76-R77) [[3]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L103-R99) [[4]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L124-R121) [[5]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L149-R141) [[6]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L168-R161) [[7]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L196-R184) [[8]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L218-R207) [[9]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L250-R234) [[10]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L276-R261) [[11]](diffhunk://#diff-7aa6723841b37949ae56a8d73bb46a40c9f8b29f0f6a1c1a13df3fc4d44932d2L306-R286)

* [`slices/set_test.go`](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L19-R23): Reorganized tests into subtests using `t.Run` for operations like "Difference", "Items", "Each", and "Union". This enhances test clarity and structure. [[1]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L19-R23) [[2]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L30-L34) [[3]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L43-L47) [[4]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L59-L63) [[5]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291R71)

### Parallelization enhancements:

* [`cache/fixed_hash_bucket_test.go`](diffhunk://#diff-7047c9033a2f1630a984f71649a206af5e0cd821cf59673f74a91e14ea748f77R10-R11): Added `t.Parallel()` to enable parallel execution of the `Test_FixedHashBucket` test.
* [`logging/logger_test.go`](diffhunk://#diff-592d08cada4c87bd69e20d3eb1ac3b8d11c5482053528d03dd511611dcc9e517R12-R15): Introduced `t.Parallel()` for the `TestNewLogger` and its subtests, ensuring tests run concurrently. [[1]](diffhunk://#diff-592d08cada4c87bd69e20d3eb1ac3b8d11c5482053528d03dd511611dcc9e517R12-R15) [[2]](diffhunk://#diff-592d08cada4c87bd69e20d3eb1ac3b8d11c5482053528d03dd511611dcc9e517L21-R28) [[3]](diffhunk://#diff-592d08cada4c87bd69e20d3eb1ac3b8d11c5482053528d03dd511611dcc9e517R42-R46)
* [`slices/set_test.go`](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L19-R23): Enabled parallel execution for all subtests within `Test_Set`. [[1]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L19-R23) [[2]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L30-L34) [[3]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L43-L47) [[4]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291L59-L63) [[5]](diffhunk://#diff-f98376127139e15a5a579af5223cd3ece59b1597e42107eec680ebd0fb5df291R71)

### Removal of redundant code:

* [`logging/config_test.go`](diffhunk://#diff-d04d93a453da02a9f4fbf31e6d10699b2fff32af6647de10a6540087ac006ee8L5-L19): Removed the `setEnv` helper method and directly used `t.Setenv` for setting environment variables in tests. This simplifies the code and reduces unnecessary abstraction. [[1]](diffhunk://#diff-d04d93a453da02a9f4fbf31e6d10699b2fff32af6647de10a6540087ac006ee8L5-L19) [[2]](diffhunk://#diff-d04d93a453da02a9f4fbf31e6d10699b2fff32af6647de10a6540087ac006ee8L84-R74)